### PR TITLE
Fixes for Player 1 vs 2 Specific Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ By default, Naruto's ZTK transformation takes 1.5x damage. This setting allows y
 
 By default, Ukon takes 1.2x damage. This setting allows you to change this value. Sakon is not affected, only Ukon.
 
+#### Fix Kabuto 2A Scaling for Player 2
+
+When playing as Kabuto on the player 1 side, Kabuto does unscaled damage with 2A. On the player 2 side however,
+this damage is scaled. Player 1 unscaled damage is 48, while player 2 scaled damage is 26. Using this fix in
+GNTool will use unscaled damage for both player 1 and player 2.
+
+#### Fix Phantom Sword for Kisame Player 2
+
+When playing as Kisame on the player 1 side, you can make JA **unblockable** by landing with it on a specific frame;
+this is called Phantom Sword. Kisame on the player 2 side is unable to perform Phantom Sword. Using this fix in
+GNTool will allow player 2 to also perform Phantom Sword.
+
+#### Fix Phantom Sword for Zabuza Player 2
+
+When playing as Zabuza on the player 1 side, you can make JA **unblockable** by landing with it on a specific frame;
+this is called Phantom Sword. Zabuza on the player 2 side is unable to perform Phantom Sword. Using this fix in
+GNTool will allow player 2 to also perform Phantom Sword.
+
 #### Sound Effects
 
 Sound effects are stored inside .sam and .sdi files, and therefore require unpacking to listen to or replace. By using the **Extract** button you can extract a single .sam file selected by the combobox to the right. It will then open the folder that the sound effects were extracted to. After it has been extracted you can hit the randomize button to change the order of the sounds of that .sam file. When you are finished with the files, you will need to **Import** to create new .sam and .sdi files for changes to take place in the game.

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -19,6 +19,8 @@ import com.github.nicholasmoser.gecko.GeckoCodeJSON;
 import com.github.nicholasmoser.gecko.GeckoReader;
 import com.github.nicholasmoser.gecko.GeckoWriter;
 import com.github.nicholasmoser.gnt4.chr.KabutoScalingFix;
+import com.github.nicholasmoser.gnt4.chr.KisamePhantomSwordFix;
+import com.github.nicholasmoser.gnt4.chr.ZabuzaPhantomSwordFix;
 import com.github.nicholasmoser.gnt4.dol.DolHijack;
 import com.github.nicholasmoser.gnt4.seq.SeqKage;
 import com.github.nicholasmoser.gnt4.seq.Seqs;
@@ -394,6 +396,54 @@ public class MenuController {
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, "Failed to Apply Kabuto Scaling Fix", e);
       Message.error("Failed to Apply Kabuto Scaling Fix", SEE_LOG);
+    }
+  }
+
+  @FXML
+  protected void applyKisamePhantomSwordFix() {
+    try {
+      boolean isModified = KisamePhantomSwordFix.isSeqModified(uncompressedDirectory);
+      if (isModified) {
+        String header = "Applying Kisame Phantom Sword Fix May Break Kisame";
+        String message = "Kisame's 0000.seq has been modified and is no longer vanilla. "
+            + "There is a high likelihood applying this fix will break Kisame's 0000.seq. "
+            + "Are you sure you wish to continue?";
+        boolean confirm = Message.warnConfirmation(header, message);
+        if (!confirm) {
+          return;
+        }
+      }
+      KisamePhantomSwordFix.apply(uncompressedDirectory);
+      String header = "Kisame Phantom Sword Fix Applied";
+      String message = "The Kisame Phantom Sword Fix has been applied to Kisame's 0000.seq file.";
+      Message.info(header, message);
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Failed to Apply Kisame Phantom Sword Fix", e);
+      Message.error("Failed to Apply Kisame Phantom Sword Fix", SEE_LOG);
+    }
+  }
+
+  @FXML
+  protected void applyZabuzaPhantomSwordFix() {
+    try {
+      boolean isModified = ZabuzaPhantomSwordFix.isSeqModified(uncompressedDirectory);
+      if (isModified) {
+        String header = "Applying Zabuza Phantom Sword Fix May Break Zabuza";
+        String message = "Zabuza's 0000.seq has been modified and is no longer vanilla. "
+            + "There is a high likelihood applying this fix will break Zabuza's 0000.seq. "
+            + "Are you sure you wish to continue?";
+        boolean confirm = Message.warnConfirmation(header, message);
+        if (!confirm) {
+          return;
+        }
+      }
+      ZabuzaPhantomSwordFix.apply(uncompressedDirectory);
+      String header = "Zabuza Phantom Sword Fix Applied";
+      String message = "The Zabuza Phantom Sword Fix has been applied to Zabuza's 0000.seq file.";
+      Message.info(header, message);
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Failed to Apply Zabuza Phantom Sword Fix", e);
+      Message.error("Failed to Apply Zabuza Phantom Sword Fix", SEE_LOG);
     }
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -18,6 +18,7 @@ import com.github.nicholasmoser.gecko.GeckoCodeGroup;
 import com.github.nicholasmoser.gecko.GeckoCodeJSON;
 import com.github.nicholasmoser.gecko.GeckoReader;
 import com.github.nicholasmoser.gecko.GeckoWriter;
+import com.github.nicholasmoser.gnt4.chr.KabutoScalingFix;
 import com.github.nicholasmoser.gnt4.dol.DolHijack;
 import com.github.nicholasmoser.gnt4.seq.SeqKage;
 import com.github.nicholasmoser.gnt4.seq.Seqs;
@@ -369,6 +370,30 @@ public class MenuController {
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "Failed to Update Ukon Damage Multiplier", e);
       Message.error("Failed to Update Ukon Damage Multiplier", SEE_LOG);
+    }
+  }
+
+  @FXML
+  protected void applyKabutoScalingFix() {
+    try {
+      boolean isModified = KabutoScalingFix.isSeqModified(uncompressedDirectory);
+      if (isModified) {
+        String header = "Applying Kabuto Scaling Fix May Break Kabuto";
+        String message = "Kabuto's 0000.seq has been modified and is no longer vanilla. "
+            + "There is a high likelihood applying this fix will break Kabuto's 0000.seq. "
+            + "Are you sure you wish to continue?";
+        boolean confirm = Message.warnConfirmation(header, message);
+        if (!confirm) {
+          return;
+        }
+      }
+      KabutoScalingFix.apply(uncompressedDirectory);
+      String header = "Kabuto Scaling Fix Applied";
+      String message = "The Kabuto Scaling Fix has been applied to Kabuto's 0000.seq file.";
+      Message.info(header, message);
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Failed to Apply Kabuto Scaling Fix", e);
+      Message.error("Failed to Apply Kabuto Scaling Fix", SEE_LOG);
     }
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/KabutoScalingFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/KabutoScalingFix.java
@@ -19,7 +19,7 @@ public class KabutoScalingFix {
    * Returns whether or not Kabuto's 0000.seq has been modified in the given uncompressed directory.
    *
    * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
-   * @return The current translation state.
+   * @return If Kabuto's 0000.seq has been modified.
    * @throws IOException If any I/O issues occur
    */
   public static boolean isSeqModified(Path uncompressedDir) throws IOException {
@@ -28,7 +28,7 @@ public class KabutoScalingFix {
 
   /**
    * Applies the fix to Kabuto's 0000.seq in the given uncompressed directory. Will probably break
-   * the seq file if you run it against anything that a vanilla Kabuto 0000.seq. You can comfirm
+   * the seq file if you run it against anything that a vanilla Kabuto 0000.seq. You can confirm
    * this is the case by first calling {@link #isSeqModified(Path)}.
    *
    * @param uncompressedDir The uncompressed directory of the GNT4 workspace.

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/KabutoScalingFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/KabutoScalingFix.java
@@ -1,0 +1,65 @@
+package com.github.nicholasmoser.gnt4.chr;
+
+import com.github.nicholasmoser.utils.CRC32;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A class to fix the issue where Kabuto 2A does less damage if used by player 2, compared to being
+ * used by player 1. The fix is to add a single frame to the activated 2A action. This appears to
+ * fix it due to the issue occurring on things that apply on the first frame. Since we've added a
+ * frame, the issue no longer occurs and both player 1 and player 2 do full damage.
+ */
+public class KabutoScalingFix {
+
+  public static final String KABUTO_0000_SEQ = "files/chr/kab/0000.seq";
+
+  /**
+   * Returns whether or not Kabuto's 0000.seq has been modified in the given uncompressed directory.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @return The current translation state.
+   * @throws IOException If any I/O issues occur
+   */
+  public static boolean isSeqModified(Path uncompressedDir) throws IOException {
+    return CRC32.getHash(uncompressedDir.resolve(KABUTO_0000_SEQ)) != 0xe5d95d8e;
+  }
+
+  /**
+   * Applies the fix to Kabuto's 0000.seq in the given uncompressed directory. Will probably break
+   * the seq file if you run it against anything that a vanilla Kabuto 0000.seq. You can comfirm
+   * this is the case by first calling {@link #isSeqModified(Path)}.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @throws IOException If any I/O issues occur
+   */
+  public static void apply(Path uncompressedDir) throws IOException {
+    Path filePath = uncompressedDir.resolve(KABUTO_0000_SEQ);
+    byte[] oldBytes = Files.readAllBytes(filePath);
+    byte[] newBytes = new byte[oldBytes.length + 0x14];
+    // Copy the existing seq bytes up until near the end and update offsets
+    System.arraycopy(oldBytes, 0, newBytes, 0, 0x26614);
+    newBytes[0x17] = 0x28;
+    newBytes[0x7C2] = 0x66;
+    newBytes[0x7C3] = 0x14;
+    newBytes[0x7C6] = 0x66;
+    newBytes[0x7C7] = 0x14;
+    newBytes[0x7CEB] = (byte) 0xB8;
+    newBytes[0x84E3] = (byte) 0xC4;
+    newBytes[0x8957] = 0x50;
+    newBytes[0x8F47] = 0x50;
+    newBytes[0x904F] = (byte) 0x8c;
+    newBytes[0x90BF] = 0x50;
+    newBytes[0x9483] = (byte) 0xB4;
+    // Add the fix
+    byte[] fix = new byte[] { 0x20, 0x11, 0x26, 0x3F, 0x00, 0x00, 0x00, 0x01, 0x20, 0x12, 0x00,
+        0x26, 0x01, 0x32, 0x00, 0x00, 0x00, 0x02, 0x07, 0x70 };
+    System.arraycopy(fix, 0, newBytes, 0x26614, 0x14);
+    // Add the seq footer with updated offsets after the fix
+    System.arraycopy(oldBytes, 0x26614, newBytes, 0x26614 + 0x14, 0xAC);
+    newBytes[0x26637] = 0x50;
+    newBytes[0x26677] = (byte) 0x88;
+    Files.write(filePath, newBytes);
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/KisamePhantomSwordFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/KisamePhantomSwordFix.java
@@ -4,9 +4,13 @@ import com.github.nicholasmoser.utils.CRC32;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
+/**
+ * A class to fix the issue where only Kisame only the player 1 side can Phantom Sword. Phantom Sword
+ * is where JA is unblockable if you land with it on a specific frame. The issue is fixed by adding
+ * the unblockable flag for the KF flags on the first flag of landing.
+ */
 public class KisamePhantomSwordFix {
 
   public static final String KISAME_0000_SEQ = "files/chr/kis/0000.seq";

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/KisamePhantomSwordFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/KisamePhantomSwordFix.java
@@ -1,0 +1,50 @@
+package com.github.nicholasmoser.gnt4.chr;
+
+import com.github.nicholasmoser.utils.CRC32;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class KisamePhantomSwordFix {
+
+  public static final String KISAME_0000_SEQ = "files/chr/kis/0000.seq";
+
+  /**
+   * Returns whether or not Kisame's 0000.seq has been modified in the given uncompressed directory.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @return If Kisame's 0000.seq has been modified.
+   * @throws IOException If any I/O issues occur
+   */
+  public static boolean isSeqModified(Path uncompressedDir) throws IOException {
+    return CRC32.getHash(uncompressedDir.resolve(KISAME_0000_SEQ)) != 0x8dc540a8;
+  }
+
+  /**
+   * Applies the fix to Kisame's 0000.seq in the given uncompressed directory. Will probably break
+   * the seq file if you run it against anything that a vanilla Kisame 0000.seq. You can comfirm
+   * this is the case by first calling {@link #isSeqModified(Path)}.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @throws IOException If any I/O issues occur
+   */
+  public static void apply(Path uncompressedDir) throws IOException {
+    File filePath = uncompressedDir.resolve(KISAME_0000_SEQ).toFile();
+    try (RandomAccessFile raf = new RandomAccessFile(filePath, "rw")) {
+      raf.seek(0x1C30C);
+      raf.write(0x43);
+      raf.seek(0x1C31A);
+      raf.write(0x12);
+      raf.seek(0x1C31C);
+      raf.write(0x10);
+      raf.seek(0x1C31D);
+      raf.write(0x10);
+      raf.seek(0x1C31E);
+      raf.write(0x42);
+      raf.seek(0x1C31F);
+      raf.write(0xA0);
+    }
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/ZabuzaPhantomSwordFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/ZabuzaPhantomSwordFix.java
@@ -1,0 +1,45 @@
+package com.github.nicholasmoser.gnt4.chr;
+
+import com.github.nicholasmoser.utils.CRC32;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+
+public class ZabuzaPhantomSwordFix {
+
+  public static final String ZABUZA_0000_SEQ = "files/chr/zab/0000.seq";
+
+  /**
+   * Returns whether or not Zabuza's 0000.seq has been modified in the given uncompressed directory.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @return If Zabuza's 0000.seq has been modified.
+   * @throws IOException If any I/O issues occur
+   */
+  public static boolean isSeqModified(Path uncompressedDir) throws IOException {
+    return CRC32.getHash(uncompressedDir.resolve(ZABUZA_0000_SEQ)) != 0x75a82238;
+  }
+
+  /**
+   * Applies the fix to Zabuza's 0000.seq in the given uncompressed directory. Will probably break
+   * the seq file if you run it against anything that a vanilla Zabuza 0000.seq. You can confirm
+   * this is the case by first calling {@link #isSeqModified(Path)}.
+   *
+   * @param uncompressedDir The uncompressed directory of the GNT4 workspace.
+   * @throws IOException If any I/O issues occur
+   */
+  public static void apply(Path uncompressedDir) throws IOException {
+    File filePath = uncompressedDir.resolve(ZABUZA_0000_SEQ).toFile();
+    try (RandomAccessFile raf = new RandomAccessFile(filePath, "rw")) {
+      raf.seek(0x1B868);
+      raf.write(0x43);
+      raf.seek(0x1B876);
+      raf.write(0x15);
+      raf.seek(0x1B878);
+      raf.write(0x0);
+      raf.seek(0x1B87A);
+      raf.write(0x40);
+    }
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/chr/ZabuzaPhantomSwordFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/chr/ZabuzaPhantomSwordFix.java
@@ -6,6 +6,11 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
 
+/**
+ * A class to fix the issue where only Zabuza only the player 1 side can Phantom Sword. Phantom Sword
+ * is where JA is unblockable if you land with it on a specific frame. The issue is fixed by adding
+ * the unblockable flag for the KF flags on the first flag of landing.
+ */
 public class ZabuzaPhantomSwordFix {
 
   public static final String ZABUZA_0000_SEQ = "files/chr/zab/0000.seq";

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -21,7 +21,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.nicholasmoser.gnt4.MenuController">
+<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.nicholasmoser.gnt4.MenuController">
   <MenuBar VBox.vgrow="NEVER">
     <Menu mnemonicParsing="false" text="File">
       <MenuItem mnemonicParsing="false" onAction="#openDirectory" text="Open Workspace" />
@@ -96,8 +96,12 @@
           <Button layoutX="26.0" layoutY="60.0" mnemonicParsing="false" onMouseClicked="#applyUkonDamageMultiplier" text="Apply" />
           <TextField fx:id="ukonDamageMultiplier" layoutX="81.0" layoutY="60.0" prefHeight="25.0" prefWidth="148.0" />
           <Text layoutX="241.0" layoutY="77.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Ukon Damage Taken Multiplier" wrappingWidth="179.13671875" />
-          <Button layoutX="26.0" layoutY="95.0" mnemonicParsing="false" text="Apply" onMouseClicked="#applyKabutoScalingFix" />
-          <Text layoutX="81.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Kabuto 2A Scaling for Player 2" />
+          <Button layoutX="26.0" layoutY="95.0" mnemonicParsing="false" onMouseClicked="#applyKabutoScalingFix" text="Apply" />
+          <Text layoutX="81.0" layoutY="112.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Kabuto 2A Scaling for Player 2" />
+          <Button layoutX="26.0" layoutY="130.0" mnemonicParsing="false" onMouseClicked="#applyKisamePhantomSwordFix" text="Apply" />
+          <Text layoutX="81.0" layoutY="147.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Phantom Sword for Kisame Player 2" />
+          <Button layoutX="26.0" layoutY="165.0" mnemonicParsing="false" onMouseClicked="#applyZabuzaPhantomSwordFix" text="Apply" />
+          <Text layoutX="81.0" layoutY="182.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Phantom Sword for Zabuza Player 2" />
         </AnchorPane>
       </Tab>
       <Tab text="Audio">

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -28,7 +28,7 @@
       <MenuItem accelerator="F5" mnemonicParsing="false" onAction="#refresh" text="Refresh" />
       <MenuItem accelerator="F6" mnemonicParsing="false" onAction="#toggleDarkMode" text="Toggle Dark Mode" />
       <CheckMenuItem fx:id="parallelBuild" mnemonicParsing="false" text="Parallel Build" />
-      <CheckMenuItem fx:id="pushToBackOfISO" mnemonicParsing="false" text="Push Files to Back of ISO" selected="true" />
+      <CheckMenuItem fx:id="pushToBackOfISO" mnemonicParsing="false" selected="true" text="Push Files to Back of ISO" />
       <MenuItem mnemonicParsing="false" onAction="#build" text="Build ISO" />
       <SeparatorMenuItem mnemonicParsing="false" />
       <MenuItem mnemonicParsing="false" onAction="#quit" text="Quit" />
@@ -73,7 +73,7 @@
               <CheckBox fx:id="noSlowDownOnKill" layoutX="14.0" layoutY="380.0" mnemonicParsing="false" onAction="#noSlowDownOnKill" text="No Slow Down on Kill" />
               <CheckBox fx:id="unlockAll" layoutX="14.0" layoutY="418.0" mnemonicParsing="false" onAction="#unlockAll" text="Unlock Everything" />
               <CheckBox fx:id="enableWidescreen" layoutX="14.0" layoutY="456.0" mnemonicParsing="false" onAction="#enableWidescreen" text="Widescreen 16:9" />
-              <CheckBox fx:id="xDoesNotBreakThrows" layoutX="14.0" layoutY="494.0" mnemonicParsing="false" onAction="#xDoesNotBreakThrows" text="X Does Not Break Throws" />
+              <CheckBox layoutX="14.0" layoutY="494.0" mnemonicParsing="false" onAction="#xDoesNotBreakThrows" text="X Does Not Break Throws" fx:id="xDoesNotBreakThrows" />
             </AnchorPane>
           </ScrollPane>
         </AnchorPane>
@@ -96,6 +96,8 @@
           <Button layoutX="26.0" layoutY="60.0" mnemonicParsing="false" onMouseClicked="#applyUkonDamageMultiplier" text="Apply" />
           <TextField fx:id="ukonDamageMultiplier" layoutX="81.0" layoutY="60.0" prefHeight="25.0" prefWidth="148.0" />
           <Text layoutX="241.0" layoutY="77.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Ukon Damage Taken Multiplier" wrappingWidth="179.13671875" />
+          <Button layoutX="26.0" layoutY="95.0" mnemonicParsing="false" text="Apply" onMouseClicked="#applyKabutoScalingFix" />
+          <Text layoutX="81.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Kabuto 2A Scaling for Player 2" />
         </AnchorPane>
       </Tab>
       <Tab text="Audio">


### PR DESCRIPTION
There are three things in vanilla GNT4 that are affected by whether or not you are player 1 or player 2. These include:

- Kabuto 2A Scaling for Player 2
- Phantom Sword Only Usable by Kisame Player 1
- Phantom Sword Only Usable by Zabuza Player 1

I have added new fixes to GNTool that will fix all three of these. For more information regarding them see the updated to the README.md.