### PR TITLE
Add Support for Unpacking/Repacking PS2/PSP FPK Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,19 @@ This allows you to compare two ISOs to find differences between them. It will al
 
 #### FPK Unpacker for GameCube
 
-This allows you to unpack an FPK file for any Eighting title on the GameCube.
+This allows you to unpack an FPK file for most Eighting titles on the GameCube.
 
 #### FPK Unpacker for Wii
 
-This allows you to unpack an FPK file for any Eighting title on the Wii.
+This allows you to unpack an FPK file for most Eighting titles on the Wii.
+
+#### FPK Unpacker for PS2/PSP
+
+This allows you to unpack an FPK file for most Eighting titles on the PS2 and PSP.
 
 #### FPK Repacker for GameCube
 
-This allows you to repack an FPK file for any Eighting title on the GameCube.
+This allows you to repack an FPK file for most Eighting titles on the GameCube.
 
 There is an optional button at the bottom of the window titled **Load Template**. This button will
 allow you to load a .txt file with file paths separated by newlines. This allows quicker repacking
@@ -101,7 +105,15 @@ for FPKs you intend to repack more than once.
 
 #### FPK Repacker for Wii
 
-This allows you to repack an FPK file for any Eighting title on the Wii.
+This allows you to repack an FPK file for most Eighting titles on the Wii.
+
+There is an optional button at the bottom of the window titled **Load Template**. This button will
+allow you to load a .txt file with file paths separated by newlines. This allows quicker repacking
+for FPKs you intend to repack more than once.
+
+#### FPK Repacker for PS2/PSP
+
+This allows you to repack an FPK file for most Eighting titles on the PS2 and PSP.
 
 There is an optional button at the bottom of the window titled **Load Template**. This button will
 allow you to load a .txt file with file paths separated by newlines. This allows quicker repacking

--- a/src/main/java/com/github/nicholasmoser/FPKPacker.java
+++ b/src/main/java/com/github/nicholasmoser/FPKPacker.java
@@ -134,7 +134,8 @@ public class FPKPacker {
       // Set the offset to -1 for now, we cannot figure it out until we have all of
       // the files
       String shiftJisPath = ByteUtils.encodeShiftJis(child.getCompressedPath());
-      FPKFileHeader header = new FPKFileHeader(shiftJisPath, output.length, input.length, false);
+      // TODO: Remove GameCube FPK format assumption (short paths, big endian)
+      FPKFileHeader header = new FPKFileHeader(shiftJisPath, output.length, input.length, false, true);
       newFPKs.add(new FPKFile(header, output));
       LOGGER.info(String.format("%s has been compressed from %d bytes to %d bytes.",
           child.getFilePath(), input.length, output.length));

--- a/src/main/java/com/github/nicholasmoser/FPKPacker.java
+++ b/src/main/java/com/github/nicholasmoser/FPKPacker.java
@@ -31,15 +31,21 @@ public class FPKPacker {
 
   private final Workspace workspace;
 
+  private final boolean longPaths;
+
+  private final boolean bigEndian;
+
   /**
    * Creates a new FPK packer for a workspace.
    *
    * @param workspace The workspace to pack the FPKs for.
    */
-  public FPKPacker(Workspace workspace) {
+  public FPKPacker(Workspace workspace, boolean longPaths, boolean bigEndian) {
     this.workspace = workspace;
     this.compressedDirectory = workspace.getCompressedDirectory();
     this.uncompressedDirectory = workspace.getUncompressedDirectory();
+    this.longPaths = longPaths;
+    this.bigEndian = bigEndian;
   }
 
   /**
@@ -150,7 +156,7 @@ public class FPKPacker {
     }
 
     // FPK Header
-    byte[] fpkBytes = FPKUtils.createFPKHeader(newFPKs.size(), outputSize);
+    byte[] fpkBytes = FPKUtils.createFPKHeader(newFPKs.size(), outputSize, bigEndian);
     // File headers
     for (FPKFile file : newFPKs) {
       fpkBytes = Bytes.concat(fpkBytes, file.getHeader().getBytes());

--- a/src/main/java/com/github/nicholasmoser/FPKUnpacker.java
+++ b/src/main/java/com/github/nicholasmoser/FPKUnpacker.java
@@ -35,10 +35,11 @@ public class FPKUnpacker {
    *
    * @param inputDirectory The input directory to unpack.
    * @param fileNames      The optional list of file names to fix for the unpacking.
-   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
-   * @param bigEndian If the FPK is big-endian (instead of little-endian).
+   * @param longPaths      If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian      If the FPK is big-endian (instead of little-endian).
    */
-  public FPKUnpacker(Path inputDirectory, Optional<FileNames> fileNames, boolean longPaths, boolean bigEndian) {
+  public FPKUnpacker(Path inputDirectory, Optional<FileNames> fileNames, boolean longPaths,
+      boolean bigEndian) {
     if (!Files.isDirectory(inputDirectory)) {
       throw new IllegalArgumentException(inputDirectory + " is not a directory.");
     }
@@ -95,8 +96,9 @@ public class FPKUnpacker {
    *
    * @param fpkPath         The path to the fpk file.
    * @param outputDirectory The path to the output directory.
-   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
-   * @param bigEndian If the FPK is big-endian (instead of little-endian).
+   * @param fileNames       Optional full file names to fix truncation.
+   * @param longPaths       If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian       If the FPK is big-endian (instead of little-endian).
    * @throws IOException If there is an I/O related exception.
    */
   public static void extractFPK(Path fpkPath, Path outputDirectory, Optional<FileNames> fileNames,
@@ -108,7 +110,7 @@ public class FPKUnpacker {
 
       List<FPKFileHeader> fpkHeaders = new ArrayList<>(fileCount);
       for (int i = 0; i < fileCount; i++) {
-        fpkHeaders.add(FPKUtils.readFPKFileHeader(is,longPaths, bigEndian));
+        fpkHeaders.add(FPKUtils.readFPKFileHeader(is, longPaths, bigEndian));
         bytesRead += longPaths ? 48 : 32;
       }
 

--- a/src/main/java/com/github/nicholasmoser/ToolController.java
+++ b/src/main/java/com/github/nicholasmoser/ToolController.java
@@ -32,6 +32,7 @@ public class ToolController {
   private static final String FPK_UNPACKER_PS2 = "FPK Unpacker (PS2/PSP)";
   private static final String FPK_REPACKER_GC = "FPK Repacker (GameCube)";
   private static final String FPK_REPACKER_WII = "FPK Repacker (Wii)";
+  private static final String FPK_REPACKER_PS2 = "FPK Repacker (PS2/PSP)";
   private static final String TXG2TPL = "TXG2TPL";
 
   @FXML
@@ -50,6 +51,7 @@ public class ToolController {
     items.add(FPK_UNPACKER_PS2);
     items.add(FPK_REPACKER_GC);
     items.add(FPK_REPACKER_WII);
+    items.add(FPK_REPACKER_PS2);
     items.add(TXG2TPL);
   }
 
@@ -80,6 +82,7 @@ public class ToolController {
       switch (tool) {
         case FPK_REPACKER_GC -> FPKRepackerTool.repackGamecubeFPK();
         case FPK_REPACKER_WII -> FPKRepackerTool.repackWiiFPK();
+        case FPK_REPACKER_PS2 -> FPKRepackerTool.repackPS2FPK();
         case ISO_EXTRACTOR_GC -> ISOExtractorTool.extractGameCubeISO();
         case FPK_UNPACKER_GC -> FPKUnpackerTool.unpackGamecubeFPK();
         case FPK_UNPACKER_WII -> FPKUnpackerTool.unpackWiiFPK();

--- a/src/main/java/com/github/nicholasmoser/ToolController.java
+++ b/src/main/java/com/github/nicholasmoser/ToolController.java
@@ -29,6 +29,7 @@ public class ToolController {
   private static final String ISO_COMPARE_GC = "ISO Compare (GameCube)";
   private static final String FPK_UNPACKER_GC = "FPK Unpacker (GameCube)";
   private static final String FPK_UNPACKER_WII = "FPK Unpacker (Wii)";
+  private static final String FPK_UNPACKER_PS2 = "FPK Unpacker (PS2/PSP)";
   private static final String FPK_REPACKER_GC = "FPK Repacker (GameCube)";
   private static final String FPK_REPACKER_WII = "FPK Repacker (Wii)";
   private static final String TXG2TPL = "TXG2TPL";
@@ -46,6 +47,7 @@ public class ToolController {
     items.add(ISO_COMPARE_GC);
     items.add(FPK_UNPACKER_GC);
     items.add(FPK_UNPACKER_WII);
+    items.add(FPK_UNPACKER_PS2);
     items.add(FPK_REPACKER_GC);
     items.add(FPK_REPACKER_WII);
     items.add(TXG2TPL);
@@ -81,6 +83,7 @@ public class ToolController {
         case ISO_EXTRACTOR_GC -> ISOExtractorTool.extractGameCubeISO();
         case FPK_UNPACKER_GC -> FPKUnpackerTool.unpackGamecubeFPK();
         case FPK_UNPACKER_WII -> FPKUnpackerTool.unpackWiiFPK();
+        case FPK_UNPACKER_PS2 -> FPKUnpackerTool.unpackPS2FPK();
         case ISO_PATCHER_GC -> ISOPatcher.patchGameCubeISO();
         case ISO_COMPARE_GC -> ISOCompareTool.compareGameCubeISO();
         case TXG2TPL -> TXG2TPLTool.run();

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Extractor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Extractor.java
@@ -63,7 +63,7 @@ public class GNT4Extractor implements Extractor {
       LOGGER.info(String.format("Copying %s to %s", compressed, uncompressed));
       FileUtils.copyFolder(compressed, uncompressed);
       Optional<FileNames> gnt4FileNames = Optional.of(new GNT4FileNames());
-      FPKUnpacker unpacker = new FPKUnpacker(uncompressed, gnt4FileNames, false);
+      FPKUnpacker unpacker = new FPKUnpacker(uncompressed, gnt4FileNames, false, true);
       unpacker.unpackDirectory();
       unpacked = true;
     }

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Files.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Files.java
@@ -63,7 +63,8 @@ public class GNT4Files {
    */
   public void initState() throws IOException {
     loadVanillaState();
-    this.gntFiles = ProtobufUtils.createBinary(uncompressedDirectory, allowedWorkspaceFiles);
+    this.gntFiles = ProtobufUtils
+        .createBinary(uncompressedDirectory, allowedWorkspaceFiles, false, true);
     try (OutputStream os = Files.newOutputStream(workspaceState)) {
       gntFiles.writeTo(os);
     }
@@ -71,11 +72,12 @@ public class GNT4Files {
 
   /**
    * Returns a new GNTFiles object reflecting the current workspace state.
+   *
    * @return A new GNTFiles object reflecting the current workspace state.
    * @throws IOException If an I/O error occurs.
    */
   public GNTFiles getNewWorkspaceState() throws IOException {
-    return ProtobufUtils.createBinary(uncompressedDirectory, allowedWorkspaceFiles);
+    return ProtobufUtils.createBinary(uncompressedDirectory, allowedWorkspaceFiles, false, true);
   }
 
   /**
@@ -247,7 +249,8 @@ public class GNT4Files {
         if (filePath.equals(child.getFilePath())) {
           Path saved = compressedDirectory.resolve(gntFile.getFilePath());
           Path current = uncompressedDirectory.resolve(filePath);
-          byte[] bytes = FPKUtils.getChildBytes(saved, child.getCompressedPath());
+          byte[] bytes = FPKUtils.getChildBytes(saved, child.getCompressedPath(), false,
+              true);
           Files.write(current, bytes);
           return;
         }

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -522,7 +522,7 @@ public class MenuController {
         try {
           if (repack) {
             updateMessage("Repacking FPKs...");
-            FPKPacker fpkPacker = new FPKPacker(workspace);
+            FPKPacker fpkPacker = new FPKPacker(workspace, false, true);
             fpkPacker.pack(changedFiles.getItems(), parallelBuild.isSelected());
           }
           updateMessage("Building ISO...");

--- a/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
@@ -89,6 +89,7 @@ public class FPKRepackerTool {
    */
   private static void createRepackWindow(Path fpkPath, boolean longPaths, boolean bigEndian)
       throws IOException {
+    currentDirectory = fpkPath.getParent().toFile();
     List<FPKFileHeader> fpkHeaders = getFileHeaders(fpkPath, longPaths, bigEndian);
     int numHeaders = fpkHeaders.size();
     Stage stage = new Stage();

--- a/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
@@ -233,7 +233,7 @@ public class FPKRepackerTool {
             // Set the offset to -1 for now, we cannot figure it out until we have all of
             // the files
             FPKFileHeader newHeader = new FPKFileHeader(header.getFileName(), output.length,
-                input.length, longPaths);
+                input.length, longPaths, bigEndian);
             newFPKs.add(new FPKFile(newHeader, output));
             LOGGER.info(String.format("%s has been compressed from %d bytes to %d bytes.",
                 filePath, input.length, output.length));

--- a/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
@@ -279,7 +279,9 @@ public class FPKRepackerTool {
         return null;
       }
     };
-    Stage loadingWindow = GUIUtils.createLoadingWindow("Repacking FPK", task);
+    double width = longPaths ? 600 : 450;
+    double height = 200;
+    Stage loadingWindow = GUIUtils.createLoadingWindow("Repacking FPK", task, width, height);
     task.setOnSucceeded(event -> {
       Message.info("FPK Repacked", "FPK repacking complete.");
       loadingWindow.close();

--- a/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/FPKRepackerTool.java
@@ -51,8 +51,7 @@ public class FPKRepackerTool {
     if (optionalFPK.isEmpty()) {
       return;
     }
-    List<FPKFileHeader> fpkHeaders = getGCFileHeaders(optionalFPK.get());
-    createRepackWindow(fpkHeaders, false);
+    createRepackWindow(optionalFPK.get(), false, true);
   }
 
   /**
@@ -65,17 +64,32 @@ public class FPKRepackerTool {
     if (optionalFPK.isEmpty()) {
       return;
     }
-    List<FPKFileHeader> fpkHeaders = getWiiFileHeaders(optionalFPK.get());
-    createRepackWindow(fpkHeaders, true);
+    createRepackWindow(optionalFPK.get(), true, true);
+  }
+
+  /**
+   * Repack an FPK file on the PS2/PSP.
+   *
+   * @throws IOException If there is an I/O related exception.
+   */
+  public static void repackPS2FPK() throws IOException {
+    Optional<Path> optionalFPK = Choosers.getInputFPK(GNTool.USER_HOME);
+    if (optionalFPK.isEmpty()) {
+      return;
+    }
+    createRepackWindow(optionalFPK.get(), true, false);
   }
 
   /**
    * Creates an FPK repack window with each FPK file entry.
    *
-   * @param fpkHeaders The list of FPK file entry headers.
-   * @param isWii      Whether the FPK is Wii or not (GameCube otherwise).
+   * @param fpkPath   The path to the FPK file.
+   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian If the FPK is big-endian (instead of little-endian).
    */
-  private static void createRepackWindow(List<FPKFileHeader> fpkHeaders, boolean isWii) {
+  private static void createRepackWindow(Path fpkPath, boolean longPaths, boolean bigEndian)
+      throws IOException {
+    List<FPKFileHeader> fpkHeaders = getFileHeaders(fpkPath, longPaths, bigEndian);
     int numHeaders = fpkHeaders.size();
     Stage stage = new Stage();
     GUIUtils.setIcons(stage);
@@ -131,7 +145,7 @@ public class FPKRepackerTool {
       if (outputFPK.isEmpty()) {
         return;
       }
-      repackFPK(fpkHeaders, filePaths, outputFPK.get(), isWii);
+      repackFPK(fpkHeaders, filePaths, outputFPK.get(), longPaths, bigEndian);
     });
 
     // Load template button and accompanying logic
@@ -192,10 +206,11 @@ public class FPKRepackerTool {
    *
    * @param fpkHeaders The list of existing FPK headers.
    * @param filePaths  The list of new file paths for the FPK.
-   * @param outputFPK  The output FPK.
+   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian If the FPK is big-endian (instead of little-endian).
    */
   private static void repackFPK(List<FPKFileHeader> fpkHeaders, List<String> filePaths,
-      Path outputFPK, boolean isWii) {
+      Path outputFPK, boolean longPaths, boolean bigEndian) {
     Task<Void> task = new Task<>() {
       @Override
       public Void call() {
@@ -218,7 +233,7 @@ public class FPKRepackerTool {
             // Set the offset to -1 for now, we cannot figure it out until we have all of
             // the files
             FPKFileHeader newHeader = new FPKFileHeader(header.getFileName(), output.length,
-                input.length, isWii);
+                input.length, longPaths);
             newFPKs.add(new FPKFile(newHeader, output));
             LOGGER.info(String.format("%s has been compressed from %d bytes to %d bytes.",
                 filePath, input.length, output.length));
@@ -226,7 +241,7 @@ public class FPKRepackerTool {
           updateMessage("Writing FPK...");
 
           int outputSize = 16; // FPK header is 16 bytes so start with that.
-          if (isWii) {
+          if (longPaths) {
             outputSize += newFPKs.size() * 48; // Each Wii FPK file header is 48 bytes
           } else {
             outputSize += newFPKs.size() * 32; // Each GameCube FPK file header is 32 bytes
@@ -245,7 +260,7 @@ public class FPKRepackerTool {
           }
 
           // FPK Header
-          byte[] fpkBytes = FPKUtils.createFPKHeader(newFPKs.size(), outputSize);
+          byte[] fpkBytes = FPKUtils.createFPKHeader(newFPKs.size(), outputSize, bigEndian);
           // File headers
           for (FPKFile file : newFPKs) {
             fpkBytes = Bytes.concat(fpkBytes, file.getHeader().getBytes());
@@ -279,34 +294,19 @@ public class FPKRepackerTool {
   /**
    * Get the list of file headers from a GameCube FPK at the given path.
    *
-   * @param fpkPath The path to the FPK.
+   * @param fpkPath   The path to the FPK.
+   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian If the FPK is big-endian (instead of little-endian).
    * @return The FPK file headers.
    * @throws IOException If there is an exception relating to the FPK file input.
    */
-  private static List<FPKFileHeader> getGCFileHeaders(Path fpkPath) throws IOException {
+  private static List<FPKFileHeader> getFileHeaders(Path fpkPath, boolean longPaths,
+      boolean bigEndian) throws IOException {
     try (InputStream is = Files.newInputStream(fpkPath)) {
-      int fileCount = FPKUtils.readFPKHeader(is);
+      int fileCount = FPKUtils.readFPKHeader(is, bigEndian);
       List<FPKFileHeader> fpkHeaders = new ArrayList<>(fileCount);
       for (int i = 0; i < fileCount; i++) {
-        fpkHeaders.add(FPKUtils.readGCFPKFileHeader(is));
-      }
-      return fpkHeaders;
-    }
-  }
-
-  /**
-   * Get the list of file headers from a Wii FPK at the given path.
-   *
-   * @param fpkPath The path to the FPK.
-   * @return The FPK file headers.
-   * @throws IOException If there is an exception relating to the FPK file input.
-   */
-  private static List<FPKFileHeader> getWiiFileHeaders(Path fpkPath) throws IOException {
-    try (InputStream is = Files.newInputStream(fpkPath)) {
-      int fileCount = FPKUtils.readFPKHeader(is);
-      List<FPKFileHeader> fpkHeaders = new ArrayList<>(fileCount);
-      for (int i = 0; i < fileCount; i++) {
-        fpkHeaders.add(FPKUtils.readWiiFPKFileHeader(is));
+        fpkHeaders.add(FPKUtils.readFPKFileHeader(is, longPaths, bigEndian));
       }
       return fpkHeaders;
     }

--- a/src/main/java/com/github/nicholasmoser/tools/FPKUnpackerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/FPKUnpackerTool.java
@@ -27,7 +27,7 @@ public class FPKUnpackerTool {
     if (outputPath.isEmpty()) {
       return;
     }
-    unpack(fpk, outputPath.get(), false);
+    unpack(fpk, outputPath.get(), false, true);
   }
 
   public static void unpackWiiFPK() {
@@ -41,7 +41,21 @@ public class FPKUnpackerTool {
     if (outputPath.isEmpty()) {
       return;
     }
-    unpack(fpk, outputPath.get(), true);
+    unpack(fpk, outputPath.get(), true, true);
+  }
+
+  public static void unpackPS2FPK() {
+
+    Optional<Path> optionalFPK = Choosers.getInputFPK(GNTool.USER_HOME);
+    if (optionalFPK.isEmpty()) {
+      return;
+    }
+    Path fpk = optionalFPK.get();
+    Optional<Path> outputPath = Choosers.getOutputWorkspaceDirectory(fpk.getParent().toFile());
+    if (outputPath.isEmpty()) {
+      return;
+    }
+    unpack(fpk, outputPath.get(), true, false);
   }
 
   /**
@@ -49,15 +63,16 @@ public class FPKUnpackerTool {
    *
    * @param fpkPath The path to the fpk file.
    * @param outputPath The path to the output directory.
-   * @param isWii If the fpk is a Wii fpk or not (GameCube otherwise).
+   * @param longPaths If the FPK inner file paths are 32-bytes (instead of 16-bytes).
+   * @param bigEndian If the FPK is big-endian (instead of little-endian).
    */
-  private static void unpack(Path fpkPath, Path outputPath, boolean isWii) {
+  private static void unpack(Path fpkPath, Path outputPath, boolean longPaths, boolean bigEndian) {
     Task<Void> task = new Task<>() {
       @Override
       public Void call() {
         updateMessage(String.format("Unpacking %s", fpkPath.getFileName()));
         try {
-          FPKUnpacker.extractFPK(fpkPath, outputPath, Optional.empty(), isWii);
+          FPKUnpacker.extractFPK(fpkPath, outputPath, Optional.empty(), longPaths, bigEndian);
         } catch (IOException ex) {
           LOGGER.log(Level.SEVERE, "Error", ex);
           throw new RuntimeException(ex);

--- a/src/main/java/com/github/nicholasmoser/utils/ByteUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/ByteUtils.java
@@ -49,6 +49,22 @@ public class ByteUtils {
   }
 
   /**
+   * Converts a uint32 (as a long) to a 4-byte little-endian byte array. Values over 4,294,967,295 will
+   * wrap back to zero.
+   *
+   * @param value The uint32 (as a long) as a 4-byte little-endian array.
+   * @return The output bytes.
+   */
+  public static byte[] fromUint32LE(long value) {
+    return new byte[]{
+        (byte) (value),
+        (byte) (value >> 8),
+        (byte) (value >> 16),
+        (byte) (value >> 24)
+    };
+  }
+
+  /**
    * Converts a uint32 (as a long) to a 4-byte big-endian byte array. Values over 4,294,967,295 will
    * wrap back to zero.
    *

--- a/src/main/java/com/github/nicholasmoser/utils/FPKUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/FPKUtils.java
@@ -81,7 +81,7 @@ public class FPKUtils {
     int compressedSize = bigEndian ? buf.getInt() : buf.order(ByteOrder.LITTLE_ENDIAN).getInt();
     buf = ByteBuffer.wrap(uncompressedSizeWord);
     int uncompressedSize = bigEndian ? buf.getInt() : buf.order(ByteOrder.LITTLE_ENDIAN).getInt();
-    return new FPKFileHeader(fileName, offset, compressedSize, uncompressedSize, longPaths);
+    return new FPKFileHeader(fileName, offset, compressedSize, uncompressedSize, longPaths, bigEndian);
   }
 
   /**

--- a/src/main/java/com/github/nicholasmoser/utils/FPKUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/FPKUtils.java
@@ -101,7 +101,7 @@ public class FPKUtils {
       int bytesRead = 16;
       for (int i = 0; i < fileCount; i++) {
         FPKFileHeader header = readFPKFileHeader(is, longPaths, bigEndian);
-        bytesRead += 32;
+        bytesRead += longPaths ? 48 : 32;
         if (child.equals(header.getFileName())) {
           int bytesToSkip = header.getOffset() - bytesRead;
           if (is.skip(bytesToSkip) != bytesToSkip) {

--- a/src/main/java/com/github/nicholasmoser/utils/GUIUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/GUIUtils.java
@@ -44,13 +44,26 @@ public class GUIUtils {
   private static final Path DARK_MODE_DISABLED = Paths.get("DARK_MODE_DISABLED");
 
   /**
-   * Creates a new loading window for a specified task.
+   * Creates a new loading window for a specified task with the default window size.
    * 
    * @param title The title of the window.
    * @param task The task to perform.
    * @return The loading window.
    */
   public static Stage createLoadingWindow(String title, Task<?> task) {
+    return createLoadingWindow(title, task, 450, 200);
+  }
+
+  /**
+   * Creates a new loading window for a specified task with the given size.
+   *
+   * @param title The title of the window.
+   * @param task The task to perform.
+   * @param width The width of the window.
+   * @param height The height of the window.
+   * @return The loading window.
+   */
+  public static Stage createLoadingWindow(String title, Task<?> task, double width, double height) {
     Stage loadingWindow = new Stage();
     loadingWindow.initModality(Modality.APPLICATION_MODAL);
     loadingWindow.initStyle(StageStyle.UNDECORATED);
@@ -72,7 +85,7 @@ public class GUIUtils {
     flow.add(progressIndicator, 0, 1);
     flow.setStyle(BORDER);
 
-    Scene dialogScene = new Scene(flow, 450, 200);
+    Scene dialogScene = new Scene(flow, width, height);
     loadingWindow.setScene(dialogScene);
     loadingWindow.show();
 

--- a/src/test/java/com/github/nicholasmoser/ProtoBufCreatorTest.java
+++ b/src/test/java/com/github/nicholasmoser/ProtoBufCreatorTest.java
@@ -21,7 +21,7 @@ public class ProtoBufCreatorTest {
   public void testCreateDiffBinary() throws Exception {
     Path compressed = Paths.get("D:/GNT/aaa/uncompressed");
     Path output = Paths.get("D:/GNT/aaa/testCreateDiffBinary.bin");
-    GNTFiles gntFiles = ProtobufUtils.createBinary(compressed, null);
+    GNTFiles gntFiles = ProtobufUtils.createBinary(compressed, null, false, true);
     try (OutputStream os = Files.newOutputStream(output)) {
       gntFiles.writeTo(os);
     }
@@ -38,7 +38,7 @@ public class ProtoBufCreatorTest {
     Path compressed = Paths.get("D:/GNT/bbb/compressed");
     Path output = Paths
         .get("./src/main/resources/com/github/nicholasmoser/gnt4/vanilla_with_fpks.bin");
-    GNTFiles gntFiles = ProtobufUtils.createBinary(compressed, null, true);
+    GNTFiles gntFiles = ProtobufUtils.createBinary(compressed, null, true, false, true);
     try (OutputStream os = Files.newOutputStream(output)) {
       gntFiles.writeTo(os);
     }

--- a/src/test/java/com/github/nicholasmoser/utils/ByteUtilsTest.java
+++ b/src/test/java/com/github/nicholasmoser/utils/ByteUtilsTest.java
@@ -84,6 +84,78 @@ public class ByteUtilsTest {
   }
 
   /**
+   * Edge case testing for {@link ByteUtils#fromUint32LE(long)}
+   */
+  @Test
+  public void testFromUint32LE() {
+    byte[] bytes = ByteUtils.fromUint32LE(-1L);
+    assertEquals((byte) 0xFF, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0xFF, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0L);
+    assertEquals((byte) 0x00, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x00, bytes[2]);
+    assertEquals((byte) 0x00, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(11L);
+    assertEquals((byte) 0x0B, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x00, bytes[2]);
+    assertEquals((byte) 0x00, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0x3C070002L);
+    assertEquals((byte) 0x02, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x07, bytes[2]);
+    assertEquals((byte) 0x3C, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0x81030002L);
+    assertEquals((byte) 0x02, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x03, bytes[2]);
+    assertEquals((byte) 0x81, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(Integer.MAX_VALUE - 1L);
+    assertEquals((byte) 0xFE, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0x7F, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(Integer.MAX_VALUE);
+    assertEquals((byte) 0xFF, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0x7F, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(Integer.MAX_VALUE + 1L);
+    assertEquals((byte) 0x00, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x00, bytes[2]);
+    assertEquals((byte) 0x80, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0xFFFFFFFFL - 1L);
+    assertEquals((byte) 0xFE, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0xFF, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0xFFFFFFFFL);
+    assertEquals((byte) 0xFF, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0xFF, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(0xFFFFFFFFL + 1L);
+    assertEquals((byte) 0x00, bytes[0]);
+    assertEquals((byte) 0x00, bytes[1]);
+    assertEquals((byte) 0x00, bytes[2]);
+    assertEquals((byte) 0x00, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(Long.MAX_VALUE - 1L);
+    assertEquals((byte) 0xFE, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0xFF, bytes[3]);
+    bytes = ByteUtils.fromUint32LE(Long.MAX_VALUE);
+    assertEquals((byte) 0xFF, bytes[0]);
+    assertEquals((byte) 0xFF, bytes[1]);
+    assertEquals((byte) 0xFF, bytes[2]);
+    assertEquals((byte) 0xFF, bytes[3]);
+  }
+
+  /**
    * Edge case testing for {@link ByteUtils#fromInt32(int)}
    */
   @Test


### PR DESCRIPTION
There are Eighting titles on the PS2 and PSP that have FPK files. These FPK files are little endian, whereas all GameCube and Wii FPK files are big endian. I have added new tools and logic to GNTool to add support for these little endian FPK files. I also cleaned up the FPK logic to not specify the platform, but rather the endianness and whether paths are short or long (16 vs 32 bytes).