### PR TITLE
Add spinner to modify frames before CSS models are loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ A, B, Y, and X all can break throws in GNT4. Since X can be used to break throws
 
 This patch allows you to select multiples of the same character in 4-player battle mode.
 
+#### Frames Until Model is Loaded in Character Select Screen
+
+This allows you to change the number of frames before a model is loaded in the character select
+screen (CSS). In vanilla GNT4 the model for a character will be loaded 60 frames after hovering
+over the character. The game runs in 60 frames per second, so the default is approximately 1 second.
+
+Loading the model causes the game to freeze for a quick moment, especially so when the game is
+loaded from your local file system instead of via an ISO/disc. This freeze can resort in a worse
+quality of life while playing the game. By raising the number of frames, you can make the game wait
+longer (or basically forever) before it tries to load the model.
+
+The maximum is 2147483647 frames, which would require waiting 13.6 months.
+
 #### ZTK Damage Taken Multiplier
 
 By default, Naruto's ZTK transformation takes 1.5x damage. This setting allows you to change this value.

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Codes.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Codes.java
@@ -170,11 +170,11 @@ public class GNT4Codes {
 
   // https://github.com/NicholasMoser/GNTool#Widescreen
   public static final GNT4Code PERSPECTIVE_INSTRUCTION = new GNT4Code(MAIN_DOL, 0x16B15C,
-      new byte[]{(byte)0xff, (byte)0xa0, 0x10, (byte)0x90},
-      new byte[]{(byte)0xc3, (byte)0xa2, (byte)0xa0, 0x24});
+      new byte[]{(byte) 0xff, (byte) 0xa0, 0x10, (byte) 0x90},
+      new byte[]{(byte) 0xc3, (byte) 0xa2, (byte) 0xa0, 0x24});
   public static final GNT4Code WIDESCREEN_VALUE = new GNT4Code(MAIN_DOL, 0x2220C4,
-      new byte[]{0x3f, (byte)0xa2, (byte)0x8f, 0x5c},
-      new byte[]{0x3f, (byte)0xe3, (byte)0x8e, 0x39});
+      new byte[]{0x3f, (byte) 0xa2, (byte) 0x8f, 0x5c},
+      new byte[]{0x3f, (byte) 0xe3, (byte) 0x8e, 0x39});
   public static final List<GNT4Code> WIDESCREEN_CODES = Arrays
       .asList(PERSPECTIVE_INSTRUCTION, WIDESCREEN_VALUE);
 
@@ -182,6 +182,16 @@ public class GNT4Codes {
   public static final GNT4Code X_DOES_NOT_BREAK_THROWS = new GNT4Code(MAIN_DOL, 0x602F0,
       new byte[]{0x70, 0x00, 0x22, 0x30},
       new byte[]{0x70, 0x00, 0x02, 0x30});
+
+  // https://github.com/NicholasMoser/GNTool#Load-Character-Models-in-Character-Select-Screen
+  public static final GNT4Code CSS_LOAD_CHR_MODELS_P1 = new GNT4Code(CSS_SEQ, 0x4DC8);
+  public static final GNT4Code CSS_LOAD_CHR_MODELS_P2 = new GNT4Code(CSS_SEQ, 0x8B4C);
+  public static final GNT4Code CSS_FFA_LOAD_CHR_MODELS_P1 = new GNT4Code(CSS_4P_SEQ, 0x54C8);
+  public static final GNT4Code CSS_FFA_LOAD_CHR_MODELS_P2 = new GNT4Code(CSS_4P_SEQ, 0x5CE4);
+  public static final GNT4Code CSS_FFA_LOAD_CHR_MODELS_P3 = new GNT4Code(CSS_4P_SEQ, 0x65FC);
+  public static final GNT4Code CSS_FFA_LOAD_CHR_MODELS_P4 = new GNT4Code(CSS_4P_SEQ, 0x70D4);
+  public static final List<GNT4Code> CSS_LOAD_CHR_MODELS = Arrays.asList(CSS_LOAD_CHR_MODELS_P1, CSS_LOAD_CHR_MODELS_P2);
+  public static final List<GNT4Code> CSS_FFA_LOAD_CHR_MODELS = Arrays.asList(CSS_FFA_LOAD_CHR_MODELS_P1, CSS_FFA_LOAD_CHR_MODELS_P2, CSS_FFA_LOAD_CHR_MODELS_P3, CSS_FFA_LOAD_CHR_MODELS_P4);
 
   private final Path uncompressedDirectory;
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Codes.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Codes.java
@@ -183,7 +183,7 @@ public class GNT4Codes {
       new byte[]{0x70, 0x00, 0x22, 0x30},
       new byte[]{0x70, 0x00, 0x02, 0x30});
 
-  // https://github.com/NicholasMoser/GNTool#Load-Character-Models-in-Character-Select-Screen
+  // https://github.com/NicholasMoser/GNTool#Frames-Until-Model-is-Loaded-in-Character-Select-Screen
   public static final GNT4Code CSS_LOAD_CHR_MODELS_P1 = new GNT4Code(CSS_SEQ, 0x4DC8);
   public static final GNT4Code CSS_LOAD_CHR_MODELS_P2 = new GNT4Code(CSS_SEQ, 0x8B4C);
   public static final GNT4Code CSS_FFA_LOAD_CHR_MODELS_P1 = new GNT4Code(CSS_4P_SEQ, 0x54C8);

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -46,7 +46,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
-import javafx.event.ActionEvent;
 import javafx.event.EventTarget;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
@@ -69,6 +68,8 @@ public class MenuController {
   private static final String ABOUT_URL = "https://github.com/NicholasMoser/GNTool";
   private static final int DEFAULT_DEMO_TIME_OUT_SECONDS = 10;
   private static final int MAX_DEMO_TIME_OUT_SECONDS = 86400;
+  private static final int DEFAULT_CSS_MODEL_LOAD_FRAMES = 60;
+  private static final int MAX_CSS_MODEL_LOAD_FRAMES = Integer.MAX_VALUE;
   private static final String SEE_LOG = "See the log for more information.";
   private static final String DOL = "sys/main.dol";
   private Workspace workspace;
@@ -113,6 +114,9 @@ public class MenuController {
 
   @FXML
   private Spinner<Integer> demoTimeOut;
+
+  @FXML
+  private Spinner<Integer> cssModelLoad;
 
   @FXML
   private ComboBox<String> musyxSamFile;
@@ -336,6 +340,18 @@ public class MenuController {
   }
 
   @FXML
+  protected void setCssModelLoad() {
+    try {
+      int frames = cssModelLoad.getValue();
+      codes.setCodeInt(GNT4Codes.CSS_LOAD_CHR_MODELS, frames);
+      codes.setCodeInt(GNT4Codes.CSS_FFA_LOAD_CHR_MODELS, frames);
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Failed to Update the Frames Until CSS Model Load", e);
+      Message.error("Failed to Update the Frames Until CSS Model Load", SEE_LOG);
+    }
+  }
+
+  @FXML
   protected void defaultTimeOut() {
     demoTimeOut.getValueFactory().setValue(DEFAULT_DEMO_TIME_OUT_SECONDS);
     setDemoTimeOut();
@@ -345,6 +361,18 @@ public class MenuController {
   protected void maxTimeOut() {
     demoTimeOut.getValueFactory().setValue(MAX_DEMO_TIME_OUT_SECONDS);
     setDemoTimeOut();
+  }
+
+  @FXML
+  public void defaultCSSModelLoad() {
+    cssModelLoad.getValueFactory().setValue(DEFAULT_CSS_MODEL_LOAD_FRAMES);
+    setCssModelLoad();
+  }
+
+  @FXML
+  public void maxCSSModelLoad() {
+    cssModelLoad.getValueFactory().setValue(MAX_CSS_MODEL_LOAD_FRAMES);
+    setCssModelLoad();
   }
 
   @FXML
@@ -1257,6 +1285,12 @@ public class MenuController {
       xDoesNotBreakThrows.setSelected(isActive);
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, "Error getting X Does Not Break Throws Code.", e);
+    }
+    try {
+      int value = codes.getCodeInt(GNT4Codes.CSS_LOAD_CHR_MODELS_P1);
+      cssModelLoad.getValueFactory().setValue(value);
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error getting Frames Until CSS Model Load.", e);
     }
   }
 

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -42,7 +42,7 @@
       <Tab text="Menu">
         <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
           <ScrollPane prefHeight="346.0" prefWidth="640.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="573.0" prefWidth="644.0">
+            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="704.0" prefWidth="644.0">
               <CheckBox fx:id="audioFixCode" layoutX="14.0" layoutY="19.0" mnemonicParsing="false" onAction="#audioFixCode" text="Audio Fix" />
               <CheckBox fx:id="skipCutscenesCode" layoutX="14.0" layoutY="57.0" mnemonicParsing="false" onAction="#skipCutscenesCode" text="Skip Cutscenes" />
               <Button layoutX="14.0" layoutY="92.0" mnemonicParsing="false" onMouseClicked="#translate" text="Translate" />
@@ -74,8 +74,16 @@
               <CheckBox fx:id="unlockAll" layoutX="14.0" layoutY="418.0" mnemonicParsing="false" onAction="#unlockAll" text="Unlock Everything" />
               <CheckBox fx:id="enableWidescreen" layoutX="14.0" layoutY="456.0" mnemonicParsing="false" onAction="#enableWidescreen" text="Widescreen 16:9" />
               <CheckBox layoutX="14.0" layoutY="494.0" mnemonicParsing="false" onAction="#xDoesNotBreakThrows" text="X Does Not Break Throws" fx:id="xDoesNotBreakThrows" />
-              <Button layoutX="12.0" layoutY="529.0" mnemonicParsing="false" text="Apply" onAction="#allow4pDupeChrs" />
+              <Button layoutX="12.0" layoutY="529.0" mnemonicParsing="false" onAction="#allow4pDupeChrs" text="Apply" />
               <Text layoutX="69.0" layoutY="546.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Allow duplicate characters in 4-player battles" />
+              <Spinner fx:id="cssModelLoad" layoutX="11.0" layoutY="568.0" onKeyReleased="#setCssModelLoad" onMouseReleased="#setCssModelLoad" prefHeight="25.0" prefWidth="157.0">
+                <valueFactory>
+                  <javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory max="2147483647" min="0" />
+                </valueFactory>
+              </Spinner>
+              <Text layoutX="183.0" layoutY="585.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Frames Until Model is Loaded in Character Select Screen" />
+              <Button layoutX="14.0" layoutY="603.0" mnemonicParsing="false" onMouseClicked="#defaultCSSModelLoad" text="Default" />
+              <Button layoutX="78.0" layoutY="603.0" mnemonicParsing="false" onMouseClicked="#maxCSSModelLoad" text="Max" />
             </AnchorPane>
           </ScrollPane>
         </AnchorPane>


### PR DESCRIPTION
This change adds a new spinner to the main workspace menu titled "Frames Until Model is Loaded in Character Select Screen":

![image](https://user-images.githubusercontent.com/4983605/126883025-d0bffa37-b263-4779-92d3-efacc070b4b4.png)

This allows you to change the number of frames before a model is loaded in the character select screen (CSS). In vanilla GNT4 the model for a character will be loaded 60 frames after hovering over the character. The game runs in 60 frames per second, so the default is approximately 1 second. It looks like this:

![image](https://user-images.githubusercontent.com/4983605/126883021-9e0a6b55-9c7e-488b-aeb0-da2ffbf29a47.png)

Loading the model causes the game to freeze for a quick moment, especially so when the game is loaded from your local file system instead of via an ISO/disc. This freeze can resort in a worse quality of life while playing the game. By raising the number of frames, you can make the game wait longer (or basically forever) before it tries to load the model.

Here is an example of changing this value to the maximum value: 2147483647 frames (13.6 months!):

https://user-images.githubusercontent.com/4983605/126883079-725bc50d-81da-4ab5-8083-e91961daa2f8.mp4

