### PR TITLE
Download codes over HTTP

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/dol/DolHijack.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/dol/DolHijack.java
@@ -6,13 +6,13 @@ import com.github.nicholasmoser.gecko.GeckoCodeGroup;
 import com.github.nicholasmoser.gecko.InsertAsmCode;
 import com.github.nicholasmoser.gecko.active.ActiveInsertAsmCode;
 import com.github.nicholasmoser.utils.ByteUtils;
+import com.github.nicholasmoser.utils.HttpUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,6 +46,9 @@ public class DolHijack {
   public final static long END_DOL_OFFSET = 0x843FC;
 
   public final static int SIZE = (int) (END_DOL_OFFSET - START_DOL_OFFSET);
+
+  private final static String KNOWN_CODES_RESOURCE = "known_codes.json";
+  private final static String KNOWN_CODES_URL = "https://raw.githubusercontent.com/NicholasMoser/GNTool/master/src/main/resources/com/github/nicholasmoser/gnt4/dol/known_codes.json";
 
   private static JSONArray CODES;
 
@@ -270,7 +273,12 @@ public class DolHijack {
    * @throws IOException If the known codes json file cannot be read.
    */
   private static JSONArray loadCodes() throws IOException {
-    try (InputStream is = DolHijack.class.getResourceAsStream("known_codes.json")) {
+    try {
+      return HttpUtils.getJSON(KNOWN_CODES_URL);
+    } catch (Exception e) {
+      LOGGER.log(Level.WARNING, "Error downloading known codes from " + KNOWN_CODES_URL, e);
+    }
+    try (InputStream is = DolHijack.class.getResourceAsStream(KNOWN_CODES_RESOURCE)) {
       if (is == null) {
         throw new IllegalStateException("Unable to find resource known_codes.json");
       }

--- a/src/main/java/com/github/nicholasmoser/utils/HttpUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/HttpUtils.java
@@ -1,0 +1,33 @@
+package com.github.nicholasmoser.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.json.JSONArray;
+import java.net.http.HttpClient;
+
+public class HttpUtils {
+
+  /**
+   * Download a JSONArray from a URL via a GET HTTP call.
+   *
+   * @param url The URL to call.
+   * @return A JSONArray.
+   * @throws IOException If there is a failure downloading or parsing the JSONArray.
+   */
+  public static JSONArray getJSON(String url) throws IOException {
+    try {
+      HttpClient client = HttpClient.newHttpClient();
+      HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+          .header("accept", "application/json")
+          .build();
+      HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+      String body = response.body();
+      return new JSONArray(body);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module com.github.nicholasmoser {
 
   requires java.desktop;
   requires java.logging;
+  requires java.net.http;
   requires javafx.controls;
   requires javafx.fxml;
   requires javafx.graphics;


### PR DESCRIPTION
This change downloads known codes over HTTP first, and if that fails, falls back to the codes in the JSON file included with GNTool. The purpose of this is to easily add new codes to master and allow consumers to benefit from these codes without needing to download the latest version of GNTool.