### PR TITLE
Fix unpacking of files with more than one FPK parent

### DIFF
--- a/src/main/java/com/github/nicholasmoser/FPKPacker.java
+++ b/src/main/java/com/github/nicholasmoser/FPKPacker.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -66,12 +65,12 @@ public class FPKPacker {
     Set<String> changedNonFPKs = new HashSet<>();
 
     for (String changedFile : changedFiles) {
-      Optional<GNTFile> parent = workspace.getParentFPK(changedFile);
+      List<GNTFile> parents = workspace.getParentFPKs(changedFile);
       // If there is no parent, it does not belong to an FPK
-      if (parent.isPresent()) {
-        changedFPKs.add(parent.get());
-      } else {
+      if (parents.isEmpty()) {
         changedNonFPKs.add(changedFile);
+      } else {
+        changedFPKs.addAll(parents);
       }
     }
 

--- a/src/main/java/com/github/nicholasmoser/Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/Workspace.java
@@ -73,12 +73,13 @@ public interface Workspace {
   List<GNTChildFile> getFPKChildren(String filePath);
 
   /**
-   * Attempts to find the parent FPK file path of a child file path.
+   * Attempts to find the parent FPK file paths of a child file path. It is possible for there to
+   * be more than one, although that is rare.
    *
    * @param changedFile The child file path.
-   * @return The parent FPK file.
+   * @return The parent FPK files.
    */
-  Optional<GNTFile> getParentFPK(String changedFile);
+  List<GNTFile> getParentFPKs(String changedFile);
 
   /**
    * Reverts a changed file.

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Files.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Files.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -148,17 +149,18 @@ public class GNT4Files {
    * @param changedFile The child file path.
    * @return The parent FPK file if it exists.
    */
-  public Optional<GNTFile> getParentFPK(String changedFile) {
+  public List<GNTFile> getParentFPKs(String changedFile) {
     Verify.verifyNotNull(vanillaFiles, "Vanilla state has not been initialized.");
     Verify.verifyNotNull(changedFile, "Changed file cannot have null path.");
+    List<GNTFile> fpks = new ArrayList<>();
     for (GNTFile gntFile : vanillaFiles.getGntFileList()) {
       for (GNTChildFile child : gntFile.getGntChildFileList()) {
         if (changedFile.equals(child.getFilePath())) {
-          return Optional.of(gntFile);
+          fpks.add(gntFile);
         }
       }
     }
-    return Optional.empty();
+    return fpks;
   }
 
   /**

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
@@ -82,8 +82,8 @@ public class GNT4Workspace implements Workspace {
   }
 
   @Override
-  public Optional<GNTFile> getParentFPK(String changedFile) {
-    return gnt4Files.getParentFPK(changedFile);
+  public List<GNTFile> getParentFPKs(String changedFile) {
+    return gnt4Files.getParentFPKs(changedFile);
   }
 
   @Override

--- a/src/test/java/com/github/nicholasmoser/gnt4/GNT4FilesTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/GNT4FilesTest.java
@@ -1,0 +1,106 @@
+package com.github.nicholasmoser.gnt4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.nicholasmoser.testing.Prereqs;
+import com.github.nicholasmoser.utils.FileUtils;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class GNT4FilesTest {
+
+  @Test
+  public void validateGNT4SoundEffectFiles() throws Exception {
+    Path uncompressed = Prereqs.getUncompressedGNT4();
+    Path tempDir = FileUtils.getTempDirectory();
+    Path defaultState = Paths.get(
+        "src/main/resources/com/github/nicholasmoser/gnt4/vanilla_with_fpks.bin");
+    Path testState = tempDir.resolve(UUID.randomUUID().toString());
+    Files.copy(defaultState, testState);
+    GNT4Files gnt4Files = new GNT4Files(uncompressed, testState);
+    gnt4Files.loadExistingState();
+
+    // Validate that most files in the game have exactly one parent FPK
+    List<Path> oneParentFPKFiles = Files.walk(uncompressed)
+        .filter(GNT4FilesTest::hasOneParentFPK)
+        .collect(Collectors.toList());
+    for (Path path : oneParentFPKFiles) {
+      String relativePath = path.toString().replace('\\', '/')
+          .replace("src/test/gnt/gnt4/uncompressed/", "");
+      assertEquals(1, gnt4Files.getParentFPKs(relativePath).size());
+    }
+
+    // Validate the few files that have multiple FPK parents
+    assertEquals(2, gnt4Files.getParentFPKs("files/omake/0002.txg").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/omake/0010.txg").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/game/3003.pro").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/game/3003.sam").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/game/3003.sdi").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/kid/3000.poo").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/kid/3000.pro").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/kid/3000.sam").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/kid/3000.sdi").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/gar/3000.poo").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/gar/3000.pro").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/gar/3000.sam").size());
+    assertEquals(2, gnt4Files.getParentFPKs("files/chr/gar/3000.sdi").size());
+    assertEquals(3, gnt4Files.getParentFPKs("files/stg/010/3000.poo").size());
+    assertEquals(3, gnt4Files.getParentFPKs("files/stg/010/3000.pro").size());
+    assertEquals(3, gnt4Files.getParentFPKs("files/stg/010/3000.sam").size());
+    assertEquals(3, gnt4Files.getParentFPKs("files/stg/010/3000.sdi").size());
+  }
+
+  /**
+   * Return if this file should have one parent FPK.
+   *
+   * @param path The file path.
+   * @return If it should have one parent FPK.
+   */
+  private static boolean hasOneParentFPK(Path path) {
+    String pathString = path.toString().replace("\\", "/");
+    switch (pathString) {
+      case "src/test/gnt/gnt4/uncompressed/files/omake/0002.txg":
+      case "src/test/gnt/gnt4/uncompressed/files/omake/0010.txg":
+      case "src/test/gnt/gnt4/uncompressed/files/game/3003.poo":
+      case "src/test/gnt/gnt4/uncompressed/files/game/3003.pro":
+      case "src/test/gnt/gnt4/uncompressed/files/game/3003.sam":
+      case "src/test/gnt/gnt4/uncompressed/files/game/3003.sdi":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/kid/3000.poo":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/kid/3000.pro":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/kid/3000.sam":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/kid/3000.sdi":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/gar/3000.poo":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/gar/3000.pro":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/gar/3000.sam":
+      case "src/test/gnt/gnt4/uncompressed/files/chr/gar/3000.sdi":
+      case "src/test/gnt/gnt4/uncompressed/files/stg/010/3000.poo":
+      case "src/test/gnt/gnt4/uncompressed/files/stg/010/3000.pro":
+      case "src/test/gnt/gnt4/uncompressed/files/stg/010/3000.sam":
+      case "src/test/gnt/gnt4/uncompressed/files/stg/010/3000.sdi":
+        return false;
+      default:
+        return Files.isRegularFile(path) && isCompressedFile(pathString);
+    }
+  }
+
+  /**
+   * Return if the file is FPK compressed. .trk, .h4m, .bnr, .img, .bin, and .dol files are not
+   * FPK compressed.
+   *
+   * @param path The file path.
+   * @return If it is FPK compressed.
+   */
+  private static boolean isCompressedFile(String path) {
+    return !path.endsWith(".trk")
+        && !path.endsWith(".h4m")
+        && !path.endsWith(".bnr")
+        && !path.endsWith(".img")
+        && !path.endsWith(".bin")
+        && !path.endsWith(".dol");
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/NicholasMoser/GNTool/issues/72
Turns out there are some files in the game that are FPK compressed, but by more than one FPK file. Therefore, when repacking FPK files GNTool must repack each FPK parent that exists.