### PR TITLE
Fix SEQ editor code overlap range comparison

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEditor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEditor.java
@@ -4,6 +4,7 @@ import com.github.nicholasmoser.Message;
 import com.github.nicholasmoser.gnt4.seq.SeqHelper;
 import com.github.nicholasmoser.utils.ByteStream;
 import com.github.nicholasmoser.utils.ByteUtils;
+import com.github.nicholasmoser.utils.Ranges;
 import java.awt.Desktop;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -523,8 +524,7 @@ public class SeqEditor {
         int existingEnd = existingStart + existingEdit.getOldBytes().length;
         int newStart = offset;
         int newEnd = offset + hijackedBytesLength;
-        boolean hasNoOverlap = (existingStart <= newEnd) && (existingEnd <= newStart);
-        if (!hasNoOverlap) {
+        if (Ranges.haveOverlap(existingStart, existingEnd, newStart, newEnd)) {
           throw new IllegalStateException(
               "New edit location conflicts with existing edit: " + existingEdit.getName());
         }

--- a/src/main/java/com/github/nicholasmoser/utils/Ranges.java
+++ b/src/main/java/com/github/nicholasmoser/utils/Ranges.java
@@ -1,0 +1,23 @@
+package com.github.nicholasmoser.utils;
+
+public class Ranges {
+
+  /**
+   * Returns whether the two given ranges overlap. The start of each range is inclusive and the
+   * end if exclusive. Therefore, [0, 4) and [4, 8) do not overlap, and each are of length 4.
+   *
+   * @param startA The start of the first range, inclusive.
+   * @param endA The end of the first range, exclusive.
+   * @param startB The start of the second range, inclusive.
+   * @param endB The end of the second range, exclusive.
+   * @return If the two ranges overlap.
+   */
+  public static boolean haveOverlap(int startA, int endA, int startB, int endB) {
+    if (startA == endA) {
+      throw new IllegalArgumentException(String.format("Cannot be equal %d and %d", startA, endA));
+    } else if (startB == endB) {
+      throw new IllegalArgumentException(String.format("Cannot be equal %d and %d", startB, endB));
+    }
+    return Math.max(startA, startB) <= Math.min(endA - 1, endB - 1);
+  }
+}

--- a/src/test/java/com/github/nicholasmoser/utils/RangesTest.java
+++ b/src/test/java/com/github/nicholasmoser/utils/RangesTest.java
@@ -37,5 +37,9 @@ public class RangesTest {
     assertFalse(Ranges.haveOverlap(0, 5, -5, 0));
     assertFalse(Ranges.haveOverlap(Integer.MIN_VALUE, 0, 0, Integer.MAX_VALUE));
     assertFalse(Ranges.haveOverlap(0, Integer.MAX_VALUE, Integer.MIN_VALUE, 0));
+
+    // Known failure case for PR-84
+    assertFalse(Ranges.haveOverlap(125220, 125228, 123592, 123600));
+    assertFalse(Ranges.haveOverlap(123592, 123600, 125220, 125228));
   }
 }

--- a/src/test/java/com/github/nicholasmoser/utils/RangesTest.java
+++ b/src/test/java/com/github/nicholasmoser/utils/RangesTest.java
@@ -1,0 +1,41 @@
+package com.github.nicholasmoser.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class RangesTest {
+  @Test
+  void testRanges() {
+    // Test cases of overlap
+    assertTrue(Ranges.haveOverlap(0, 1, 0, 1));
+    assertTrue(Ranges.haveOverlap(1, 2, 1, 2));
+    assertTrue(Ranges.haveOverlap(0, 10, 5, 6));
+    assertTrue(Ranges.haveOverlap(0, 10, 1, 9));
+    assertTrue(Ranges.haveOverlap(0, 10, 0, 10));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 5555, 7777));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 5555, 10_000));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 5555, 10_001));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 5555, Integer.MAX_VALUE));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 1337, 7777));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, 1336, 7777));
+    assertTrue(Ranges.haveOverlap(-5, 5, 0, 1));
+    assertTrue(Ranges.haveOverlap(-0, 1, -5, 5));
+    assertTrue(Ranges.haveOverlap(-10, -5, -10, -5));
+    assertTrue(Ranges.haveOverlap(-10, -5, -10, -9));
+    assertTrue(Ranges.haveOverlap(-10, -9, -10, -5));
+    assertTrue(Ranges.haveOverlap(1337, 10_000, Integer.MIN_VALUE, 7777));
+    assertTrue(Ranges.haveOverlap(Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE));
+
+    // Test cases of non-overlap
+    assertFalse(Ranges.haveOverlap(0, 4, 4, 8));
+    assertFalse(Ranges.haveOverlap(4, 8, 0, 4));
+    assertFalse(Ranges.haveOverlap(0, 32, 32, 64));
+    assertFalse(Ranges.haveOverlap(32, 64, 0, 32));
+    assertFalse(Ranges.haveOverlap(-5, 0, 0, 5));
+    assertFalse(Ranges.haveOverlap(0, 5, -5, 0));
+    assertFalse(Ranges.haveOverlap(Integer.MIN_VALUE, 0, 0, Integer.MAX_VALUE));
+    assertFalse(Ranges.haveOverlap(0, Integer.MAX_VALUE, Integer.MIN_VALUE, 0));
+  }
+}


### PR DESCRIPTION
When adding a SEQ edit in the SEQ editor, it will make sure that any new codes do not overlap existing codes. The logic for checking if two codes are overlapping is incorrect, and this PR fixes that.

Previously it did:

```java
boolean hasNoOverlap = (existingStart <= newEnd) && (existingEnd <= newStart);
```

This fails in some cases such as for the ranges [125220, 125228] and [123592, 123600]

```java
(125220 <= 123600) && (125228 <= 123592) = false
```

Which should be `true` since they have no overlap.

This has been fixed with new logic.