### PR TITLE
Better SEQ Disassembler Report

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
@@ -134,7 +134,7 @@ public class SEQ_RegCMD1 {
       }
       pushWord(bs.readWord());
       int word = bs.readWord();
-      operand.addInfo(String.format(" + offset 0x%08X", word));
+      operand.addInfo(String.format(" + offset 0x%X", word));
       pushWord(word);
     }
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
@@ -97,7 +97,7 @@ public class SEQ_RegCMD1 {
           pushWord(bs.readWord());
           operand = new SeqOperand(opcode_last_byte - 0x18, true);
         } else {
-          operand = loadOperand(opcode_last_byte, true);
+          operand = SEQ_RegGP(opcode_last_byte, true);
           pushWord(bs.readWord());
         }
       } else {
@@ -108,7 +108,7 @@ public class SEQ_RegCMD1 {
         } else if (lastSixBits < 0x30) {
           operand = new SeqOperand(lastSixBits * 4, false);
         } else {
-          operand = loadOperand(lastSixBits, false);
+          operand = SEQ_RegGP(lastSixBits, false);
         }
         pushWord(bs.readWord());
         int word = bs.readWord();
@@ -130,7 +130,7 @@ public class SEQ_RegCMD1 {
       } else if (lastSixBits < 0x30) {
         operand = new SeqOperand(lastSixBits * 4, false);
       } else {
-        operand = loadOperand(lastSixBits, false);
+        operand = SEQ_RegGP(lastSixBits, false);
       }
       pushWord(bs.readWord());
       int word = bs.readWord();
@@ -147,7 +147,7 @@ public class SEQ_RegCMD1 {
    * @return The Operand.
    * @throws IOException If an I/O error occurs.
    */
-  private Operand loadOperand(byte bitFlag, boolean returnPc) throws IOException {
+  private Operand SEQ_RegGP(byte bitFlag, boolean returnPc) throws IOException {
     return switch (bitFlag) {
       case 0x30 ->
           // Appears to be a matrix identity used for matrix multiplication of attacking hitbox

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
@@ -176,7 +176,7 @@ public class SEQ_RegCMD2 {
   public String getDescription() {
     return operands.stream()
         .map(Object::toString)
-        .collect(Collectors.joining("; "));
+        .collect(Collectors.joining(", "));
   }
 
   public List<Operand> getOperands() {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
@@ -88,7 +88,7 @@ public class SEQ_RegCMD2 {
       }
       pushWord(bs.readWord());
       int word = bs.readWord();
-      firstOperand.addInfo(String.format(" + offset 0x%08X", word));
+      firstOperand.addInfo(String.format(" + offset 0x%X", word));
       operands.add(firstOperand);
       pushWord(word);
       second_address_byte = (byte) ((bs.peekWord() >> 0x18) & 0xff);
@@ -147,7 +147,7 @@ public class SEQ_RegCMD2 {
       }
       pushWord(bs.readWord());
       int word2 = bs.readWord();
-      secondOperand.addInfo(String.format(" + offset 0x%08X", word2));
+      secondOperand.addInfo(String.format(" + offset 0x%X", word2));
       operands.add(secondOperand);
       pushWord(word2);
     }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
@@ -67,7 +67,7 @@ public class SEQ_RegCMD2 {
           operands.add(new SeqOperand(first_address_byte - 0x18, true));
           second_address_byte = (byte) (opcode & 0xff);
         } else {
-          operands.add(getOperandType(first_address_byte, true));
+          operands.add(SEQ_RegGP(first_address_byte, true));
           pushWord(bs.readWord());
           second_address_byte = (byte) ((bs.peekWord() >> 0x18) & 0xff);
         }
@@ -84,7 +84,7 @@ public class SEQ_RegCMD2 {
       } else if (lastSixBits < 0x30) {
         firstOperand = new SeqOperand(lastSixBits * 4, false);
       } else {
-        firstOperand = getOperandType(lastSixBits, false);
+        firstOperand = SEQ_RegGP(lastSixBits, false);
       }
       pushWord(bs.readWord());
       int word = bs.readWord();
@@ -107,7 +107,7 @@ public class SEQ_RegCMD2 {
           pushWord(bs.readWord());
           operands.add(new SeqOperand(second_address_byte - 0x18, true));
         } else {
-          operands.add(getOperandType(second_address_byte, true));
+          operands.add(SEQ_RegGP(second_address_byte, true));
           pushWord(bs.readWord());
         }
       } else {
@@ -119,7 +119,7 @@ public class SEQ_RegCMD2 {
         } else if (lastSixBits2 < 0x30) {
           secondOperand = new SeqOperand(lastSixBits2 * 4, false);
         } else {
-          secondOperand = getOperandType(lastSixBits2, false);
+          secondOperand = SEQ_RegGP(lastSixBits2, false);
         }
         pushWord(bs.readWord());
         int word = bs.readWord();
@@ -143,7 +143,7 @@ public class SEQ_RegCMD2 {
       } else if (lastSixBits2 < 0x30) {
         secondOperand = new SeqOperand(lastSixBits2 * 4, false);
       } else {
-        secondOperand = getOperandType(lastSixBits2, false);
+        secondOperand = SEQ_RegGP(lastSixBits2, false);
       }
       pushWord(bs.readWord());
       int word2 = bs.readWord();
@@ -209,7 +209,7 @@ public class SEQ_RegCMD2 {
    * @return The Operand.
    * @throws IOException If an I/O error occurs.
    */
-  private Operand getOperandType(byte bitFlag, boolean returnPc) throws IOException {
+  private Operand SEQ_RegGP(byte bitFlag, boolean returnPc) throws IOException {
     return switch (bitFlag) {
       case 0x30 ->
           // Appears to be a matrix identity used for matrix multiplication of attacking hitbox

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
@@ -264,7 +264,7 @@ public class SeqHelper {
       // These binaries can be after multiple different opcodes
       if (SeqHelper.isOp04700Binary(bs)) {
         byte[] bytes = bs.readBytes(0x10);
-        return Collections.singletonList(new BinaryData(offset, bytes, "; Binary data referenced by op_4700"));
+        return Collections.singletonList(new BinaryData(offset, bytes, " (Binary data referenced by op_4700)"));
       } else if (SeqHelper.isUnknownBinary2(bs)) {
         byte[] bytes = bs.readBytes(0x10);
         return Collections.singletonList(new BinaryData(offset, bytes));

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
@@ -86,7 +86,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 
 public class SeqHelper {
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
@@ -83,14 +83,11 @@ public class SeqKingHtml {
    * @return The HTML head of the document.
    */
   private static ContainerTag getHead() {
-    // Tooltip no longer used for better performance
-    String css = getCSS(); // + getTooltipCSS("b");
+    String css = getCSS();
     return head(
         title("SEQ Report"),
         style(css),
-        // Tooltip no longer used for better performance
         script(getToggleHideBytes())
-        //script(getTooltipJavascript("b", "Unconditional branch to an offset."))
     );
   }
 
@@ -142,11 +139,6 @@ public class SeqKingHtml {
         a:visited {
           color: #4E94C3;
         }
-        .tooltip {
-          position: relative;
-          display: inline-block;
-          border-bottom: 1px dotted black;
-        }
         .g {
           color: DimGray;
         }
@@ -154,49 +146,6 @@ public class SeqKingHtml {
           color: #1E1E1E;
         }
         """;
-  }
-
-  /**
-   * Returns CSS for the tooltip of the given opcode.
-   *
-   * @param opcode The opcode to get the tooltip CSS for.
-   * @return The tooltip CSS.
-   */
-  private static String getTooltipCSS(String opcode) {
-    return "." + opcode + " ." + opcode + "text {"
-        + " visibility: hidden;"
-        + " width: 120px;"
-        + " background-color: black;"
-        + " color: #fff;"
-        + " text-align: center;"
-        + " border-radius: 6px;"
-        + " padding: 5px 0;"
-        + " position: absolute;"
-        + " z-index: 1;"
-        + " }"
-        + " ." + opcode + ":hover ." + opcode + "text {"
-        + " visibility: visible;"
-        + " }\n";
-  }
-
-  /**
-   * Returns a javascript code block that adds a tooltip for the given opcode. The opcode is
-   * referenced as an HTML class. The tooltip displays the given text parameter.
-   *
-   * @param opcode The opcode of the tooltip.
-   * @param text The text to display in the tooltip.
-   * @return The javascript code block of the tooltip.
-   */
-  private static String getTooltipJavascript(String opcode, String text) {
-    return "document.addEventListener('DOMContentLoaded', (event) => {\n"
-        + "var elements = document.getElementsByClassName('" + opcode + "');\n"
-        + "for (var i = 0; i < elements.length; i++) {\n"
-        + "    var span = document.createElement('span');\n"
-        + "    span.textContent = '" + text + "';\n"
-        + "    span.className = '" + opcode + "text'; \n"
-        + "    elements[i].appendChild(span);\n"
-        + "}"
-        + "})";
   }
 
   private static String getToggleHideBytes() {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
@@ -81,11 +81,13 @@ public class SeqKingHtml {
    * @return The HTML head of the document.
    */
   private static ContainerTag getHead() {
-    String css = getCSS() + getTooltipCSS("b");
+    // Tooltip no longer used for better performance
+    String css = getCSS(); // + getTooltipCSS("b");
     return head(
         title("SEQ Report"),
-        style(css),
-        script(getTooltipJavascript("b", "Unconditional branch to an offset."))
+        style(css)
+        // Tooltip no longer used for better performance
+        //script(getTooltipJavascript("b", "Unconditional branch to an offset."))
     );
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
@@ -2,6 +2,7 @@ package com.github.nicholasmoser.gnt4.seq;
 
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.body;
+import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.head;
@@ -48,6 +49,7 @@ public class SeqKingHtml {
         getHead(),
         body(
             h1(fileName),
+            button("Toggle Hide Bytes").attr("onclick", "toggleHideBytes()"),
             getBody(opcodes)
         )
     ).withLang("en").render();
@@ -85,8 +87,9 @@ public class SeqKingHtml {
     String css = getCSS(); // + getTooltipCSS("b");
     return head(
         title("SEQ Report"),
-        style(css)
+        style(css),
         // Tooltip no longer used for better performance
+        script(getToggleHideBytes())
         //script(getTooltipJavascript("b", "Unconditional branch to an offset."))
     );
   }
@@ -147,6 +150,9 @@ public class SeqKingHtml {
         .g {
           color: DimGray;
         }
+        .v {
+          color: #1E1E1E;
+        }
         """;
   }
 
@@ -191,5 +197,24 @@ public class SeqKingHtml {
         + "    elements[i].appendChild(span);\n"
         + "}"
         + "})";
+  }
+
+  private static String getToggleHideBytes() {
+    return """
+        function toggleHideBytes() {
+          const isVisible = document.querySelector('.g');
+          if (isVisible != null) {
+            const elements = document.getElementsByClassName("g");
+            while(elements.length > 0) {
+              elements[0].className = 'v';
+            }
+          } else {
+            const elements = document.getElementsByClassName("v");
+            while(elements.length > 0) {
+              elements[0].className = 'g';
+            }
+          }
+        }
+        """;
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKingHtml.java
@@ -144,6 +144,9 @@ public class SeqKingHtml {
           display: inline-block;
           border-bottom: 1px dotted black;
         }
+        .g {
+          color: DimGray;
+        }
         """;
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup00.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup00.java
@@ -2,7 +2,7 @@ package com.github.nicholasmoser.gnt4.seq.groups;
 
 import com.github.nicholasmoser.gnt4.seq.opcodes.HardReset;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
-import com.github.nicholasmoser.gnt4.seq.opcodes.SoftReset;
+import com.github.nicholasmoser.gnt4.seq.opcodes.End;
 import com.github.nicholasmoser.gnt4.seq.opcodes.UnknownOpcode;
 import com.github.nicholasmoser.utils.ByteStream;
 import com.github.nicholasmoser.utils.ByteUtils;
@@ -13,7 +13,7 @@ public class OpcodeGroup00 {
 
   public static Opcode parse(ByteStream bs, byte opcodeByte) throws IOException {
     return switch (opcodeByte) {
-      case 0x00 -> softReset(bs);
+      case 0x00 -> end(bs);
       case 0x01 -> hardReset(bs);
       case 0x02 -> UnknownOpcode.of(0x4, bs);
       case 0x07 -> UnknownOpcode.of(0x4, bs);
@@ -21,16 +21,16 @@ public class OpcodeGroup00 {
     };
   }
 
-  public static Opcode softReset(ByteStream bs) throws IOException {
+  public static Opcode end(ByteStream bs) throws IOException {
     int offset = bs.offset();
     byte[] bytes = bs.peekWordBytes();
     int opcode = ByteUtils.toInt32(bytes);
     if ((opcode & 0xFFFF) != 0x0000) {
-      String msg = String.format("Soft reset should have 0 for third and fourth byte: %s at offset 0x%X", Arrays.toString(bytes), bs.offset());
+      String msg = String.format("End opcode should have 0 for third and fourth byte: %s at offset 0x%X", Arrays.toString(bytes), bs.offset());
       throw new IllegalStateException(msg);
     }
     bs.skip(4);
-    return new SoftReset(offset);
+    return new End(offset);
   }
 
   public static Opcode hardReset(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup01.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup01.java
@@ -66,15 +66,13 @@ public class OpcodeGroup01 {
   private static Opcode op_0101(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0105(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode branch(ByteStream bs) throws IOException {
@@ -263,8 +261,7 @@ public class OpcodeGroup01 {
       baos.write(bs.readBytes(4));
       word = bs.peekWord();
     }
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 
   private static Opcode op_0151(ByteStream bs) throws IOException {
@@ -280,7 +277,6 @@ public class OpcodeGroup01 {
       baos.write(bs.readBytes(4));
       word = bs.peekWord();
     }
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup02.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup02.java
@@ -4,6 +4,11 @@ import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD1;
 import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD2;
 import com.github.nicholasmoser.gnt4.seq.SeqHelper;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
+import com.github.nicholasmoser.gnt4.seq.opcodes.SEQ_ReqLoadPrev;
+import com.github.nicholasmoser.gnt4.seq.opcodes.SEQ_ReqLoadPrev_I;
+import com.github.nicholasmoser.gnt4.seq.opcodes.SEQ_ReqSetPrev;
+import com.github.nicholasmoser.gnt4.seq.opcodes.TskExecFunc;
+import com.github.nicholasmoser.gnt4.seq.opcodes.TskSendMsg;
 import com.github.nicholasmoser.gnt4.seq.opcodes.UnknownOpcode;
 import com.github.nicholasmoser.utils.ByteStream;
 import com.google.common.primitives.Bytes;
@@ -13,24 +18,24 @@ import java.io.IOException;
 public class OpcodeGroup02 {
   public static Opcode parse(ByteStream bs, byte opcodeByte) throws IOException {
     return switch (opcodeByte) {
-      case 0x01 -> op_0201(bs);
-      case 0x03 -> op_0203(bs);
-      case 0x05 -> op_0205(bs);
-      case 0x06 -> op_0206(bs);
-      case 0x07 -> op_0207(bs);
+      case 0x01 -> SEQ_ReqSetPrev(bs);
+      case 0x03 -> SEQ_ReqLoadPrev_I(bs);
+      case 0x05 -> SEQ_ReqLoadPrev(bs);
+      case 0x06 -> TskSendMsg(bs);
+      case 0x07 -> TskExecFunc(bs);
       case 0x08 -> op_0208(bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }
 
-  private static Opcode op_0201(ByteStream bs) throws IOException {
+  private static Opcode SEQ_ReqSetPrev(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+    return new SEQ_ReqSetPrev(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
-  private static Opcode op_0203(ByteStream bs) throws IOException {
+  private static Opcode SEQ_ReqLoadPrev_I(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -39,28 +44,30 @@ public class OpcodeGroup02 {
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
-    info.append(" with file name \"");
+    info.append(" with SEQ file \"");
     info.append(fileName);
-    info.append('"');
-    return new UnknownOpcode(offset, baos.toByteArray(), info.toString());
+    info.append(".seq\"");
+    return new SEQ_ReqLoadPrev_I(offset, baos.toByteArray(), info.toString());
   }
 
-  private static Opcode op_0205(ByteStream bs) throws IOException {
+  private static Opcode SEQ_ReqLoadPrev(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    StringBuilder info = new StringBuilder(ea.getDescription());
+    info.append(" with SEQ file from the first operand");
+    return new SEQ_ReqLoadPrev(offset, ea.getBytes(), info.toString());
   }
 
-  private static Opcode op_0206(ByteStream bs) throws IOException {
+  private static Opcode TskSendMsg(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    return new TskSendMsg(offset, ea.getBytes(), ea.getDescription());
   }
 
-  private static Opcode op_0207(ByteStream bs) throws IOException {
+  private static Opcode TskExecFunc(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    return new TskExecFunc(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0208(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup02.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup02.java
@@ -26,9 +26,8 @@ public class OpcodeGroup02 {
   private static Opcode op_0201(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_0203(ByteStream bs) throws IOException {
@@ -36,7 +35,7 @@ public class OpcodeGroup02 {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -49,28 +48,24 @@ public class OpcodeGroup02 {
   private static Opcode op_0205(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0206(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0207(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0208(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup03.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup03.java
@@ -24,21 +24,18 @@ public class OpcodeGroup03 {
   private static Opcode movr(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Movr(offset, ea.getBytes(), info);
+    return new Movr(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode push(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Push(offset, ea.getBytes(), info);
+    return new Push(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode pop(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Pop(offset, ea.getBytes(), info);
+    return new Pop(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup04.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup04.java
@@ -44,105 +44,90 @@ public class OpcodeGroup04 {
   private static Opcode movc(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Movc(offset, ea.getBytes(), info);
+    return new Movc(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode andws(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Andws(offset, ea.getBytes(), info);
+    return new Andws(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode nimply(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Nimply(offset, ea.getBytes(), info);
+    return new Nimply(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode inc(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Increment(offset, ea.getBytes(), info);
+    return new Increment(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode dec(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Decrement(offset, ea.getBytes(), info);
+    return new Decrement(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode add(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Add(offset, ea.getBytes(), info);
+    return new Add(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode sub(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Sub(offset, ea.getBytes(), info);
+    return new Sub(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode mul(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Multiply(offset, ea.getBytes(), info);
+    return new Multiply(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode div(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Divide(offset, ea.getBytes(), info);
+    return new Divide(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode and(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new And(offset, ea.getBytes(), info);
+    return new And(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode or(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Or(offset, ea.getBytes(), info);
+    return new Or(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode xor(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Xor(offset, ea.getBytes(), info);
+    return new Xor(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode subws(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new Subws(offset, ea.getBytes(), info);
+    return new Subws(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0415(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0417(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup05.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup05.java
@@ -18,7 +18,6 @@ public class OpcodeGroup05 {
   private static Opcode b_movc(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ByteMovc(offset, ea.getBytes(), info);
+    return new ByteMovc(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup06.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup06.java
@@ -38,77 +38,66 @@ public class OpcodeGroup06 {
   private static Opcode s_mov(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortMove(offset, ea.getBytes(), info);
+    return new ShortMove(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_andws(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortAndWithStore(offset, ea.getBytes(), info);
+    return new ShortAndWithStore(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_nimply(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortNimply(offset, ea.getBytes(), info);
+    return new ShortNimply(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_inc(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortIncrement(offset, ea.getBytes(), info);
+    return new ShortIncrement(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_dec(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortDecrement(offset, ea.getBytes(), info);
+    return new ShortDecrement(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_add(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortAdd(offset, ea.getBytes(), info);
+    return new ShortAdd(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_sub(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortSubtract(offset, ea.getBytes(), info);
+    return new ShortSubtract(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_or(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortOr(offset, ea.getBytes(), info);
+    return new ShortOr(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode s_subws(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new ShortSubtractWithStore(offset, ea.getBytes(), info);
+    return new ShortSubtractWithStore(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0615(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0616(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup08.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup08.java
@@ -26,35 +26,30 @@ public class OpcodeGroup08 {
   private static Opcode f_mov(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new FloatMove(offset, ea.getBytes(), info);
+    return new FloatMove(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode f_sub(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new FloatSubtract(offset, ea.getBytes(), info);
+    return new FloatSubtract(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode f_mul(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new FloatMultiply(offset, ea.getBytes(), info);
+    return new FloatMultiply(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode f_div(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new FloatDivide(offset, ea.getBytes(), info);
+    return new FloatDivide(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode f_com(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new FloatCompare(offset, ea.getBytes(), info);
+    return new FloatCompare(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup09.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup09.java
@@ -27,64 +27,55 @@ public class OpcodeGroup09 {
   private static Opcode op_0901(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0907(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0908(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0909(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_090A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_090C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_0914(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_091D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0926(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0B.java
@@ -24,42 +24,36 @@ public class OpcodeGroup0B {
   private static Opcode op_0B02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0B03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0B04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0B07(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0B0A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0B13(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0E.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0E.java
@@ -17,7 +17,6 @@ public class OpcodeGroup0E {
   public static Opcode op_0E06(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0F.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup0F.java
@@ -29,15 +29,13 @@ public class OpcodeGroup0F {
   private static Opcode op_0F0A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0F0D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0F0E(ByteStream bs) throws IOException {
@@ -45,7 +43,7 @@ public class OpcodeGroup0F {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -58,22 +56,19 @@ public class OpcodeGroup0F {
   private static Opcode op_0F0F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0F10(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0F11(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_0F14(ByteStream bs) throws IOException {
@@ -81,7 +76,7 @@ public class OpcodeGroup0F {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup10.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup10.java
@@ -27,61 +27,53 @@ public class OpcodeGroup10 {
   private static Opcode op_1000(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1004(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1005(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1007(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1009(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_100D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_101A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_101C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup11.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup11.java
@@ -19,14 +19,12 @@ public class OpcodeGroup11 {
   private static Opcode op_1106(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1107(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup12.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup12.java
@@ -38,7 +38,7 @@ public class OpcodeGroup12 {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -51,92 +51,79 @@ public class OpcodeGroup12 {
   private static Opcode op_1201(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1204(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1205(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1209(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_120A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_120B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1219(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_121A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_121B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_121D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_121E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1222(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1224(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup13.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup13.java
@@ -36,16 +36,14 @@ public class OpcodeGroup13 {
   private static Opcode op_1300(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1301(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1302(ByteStream bs) throws IOException {
@@ -53,7 +51,7 @@ public class OpcodeGroup13 {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -66,84 +64,72 @@ public class OpcodeGroup13 {
   private static Opcode op_1303(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1304(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1305(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1306(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1307(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1308(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_130B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_130E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_130F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1312(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1316(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1317(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup14.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup14.java
@@ -22,22 +22,19 @@ public class OpcodeGroup14 {
   private static Opcode op_1400(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1404(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x14);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1409(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup15.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup15.java
@@ -19,21 +19,18 @@ public class OpcodeGroup15 {
   private static Opcode op_1503(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_150A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_150B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
@@ -29,57 +29,49 @@ public class OpcodeGroup16 {
   private static Opcode op_1600(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1605(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1607(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1608(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_160F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1610(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1612(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1613(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1A.java
@@ -31,86 +31,74 @@ public class OpcodeGroup1A {
   private static Opcode op_1A02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A16(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A19(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A1B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A1D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1A1F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A20(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A21(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_1A28(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A29(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A2A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1A31(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1B.java
@@ -18,7 +18,6 @@ public class OpcodeGroup1B {
   private static Opcode op_1A02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1C.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1C.java
@@ -18,7 +18,6 @@ public class OpcodeGroup1C {
   private static Opcode op_1C00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1D.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1D.java
@@ -23,35 +23,30 @@ public class OpcodeGroup1D {
   private static Opcode op_1D02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1D03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1D05(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1D06(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1D0A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1E.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1E.java
@@ -21,21 +21,18 @@ public class OpcodeGroup1E {
   private static Opcode op_1E02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1E06(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1E07(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1F.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1F.java
@@ -28,77 +28,66 @@ public class OpcodeGroup1F {
   public static Opcode op_1F00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F01(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F05(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F06(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F07(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F09(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F0A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_1F0B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup20.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup20.java
@@ -2,6 +2,8 @@ package com.github.nicholasmoser.gnt4.seq.groups;
 
 import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD1;
 import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD2;
+import com.github.nicholasmoser.gnt4.seq.opcodes.CharacterUpdate;
+import com.github.nicholasmoser.gnt4.seq.opcodes.CharacterUpdate2;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
 import com.github.nicholasmoser.gnt4.seq.opcodes.SynchronousTimer;
 import com.github.nicholasmoser.gnt4.seq.opcodes.SynchronousTimerRun;
@@ -88,13 +90,13 @@ public class OpcodeGroup20 {
   private static Opcode op_2002(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    return new CharacterUpdate(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2003(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    return new CharacterUpdate2(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2004(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup20.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup20.java
@@ -76,372 +76,321 @@ public class OpcodeGroup20 {
   private static Opcode op_2000(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2001(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2002(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2003(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2004(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2005(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2007(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2008(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2009(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_200B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_200C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2010(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2011(ByteStream bs) throws IOException {
     int offset = bs.offset();
     int word = bs.peekWord();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     if (word == 0x2011263F) {
-      return new SynchronousTimer(offset, ea.getBytes(), info);
+      return new SynchronousTimer(offset, ea.getBytes(), ea.getDescription());
     }
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2012(ByteStream bs) throws IOException {
     int offset = bs.offset();
     int word = bs.peekWord();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     if (word == 0x20120026) {
-      return new SynchronousTimerRun(offset, ea.getBytes(), info);
+      return new SynchronousTimerRun(offset, ea.getBytes(), ea.getDescription());
     }
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2013(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2014(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2015(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2016(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2017(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2018(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2019(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_201F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2020(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2021(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2023(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2024(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2028(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2029(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_202A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_202C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_202D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_202F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2032(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2033(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2036(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2037(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2038(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2039(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_203B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_203C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_203D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_203E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_203F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2040(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2041(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2042(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
@@ -41,162 +41,140 @@ public class OpcodeGroup21 {
   private static Opcode op_2100(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2101(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2102(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2104(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2105(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2106(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2107(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2108(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_210B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_210F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2110(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2111(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2112(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2113(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2114(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2115(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2116(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2117(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_211A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_211D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_211E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2120(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
@@ -3,7 +3,10 @@ package com.github.nicholasmoser.gnt4.seq.groups;
 import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD1;
 import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD2;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
+import com.github.nicholasmoser.gnt4.seq.opcodes.SetTimerDecrement;
 import com.github.nicholasmoser.gnt4.seq.opcodes.UnknownOpcode;
+import com.github.nicholasmoser.gnt4.seq.operands.ImmediateOperand;
+import com.github.nicholasmoser.gnt4.seq.operands.Operand;
 import com.github.nicholasmoser.utils.ByteStream;
 import com.google.common.primitives.Bytes;
 import java.io.IOException;
@@ -24,7 +27,7 @@ public class OpcodeGroup21 {
       case 0x0F -> op_210F(bs);
       case 0x10 -> op_2110(bs);
       case 0x11 -> op_2111(bs);
-      case 0x12 -> op_2112(bs);
+      case 0x12 -> set_timer_decrement(bs);
       case 0x13 -> op_2113(bs);
       case 0x14 -> op_2114(bs);
       case 0x15 -> op_2115(bs);
@@ -115,10 +118,20 @@ public class OpcodeGroup21 {
     return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
-  private static Opcode op_2112(ByteStream bs) throws IOException {
+  private static Opcode set_timer_decrement(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+    StringBuilder info = new StringBuilder(ea.getDescription());
+    Operand secondOperand = ea.getSecondOperand();
+    if (secondOperand instanceof ImmediateOperand decrement) {
+      int value = decrement.getImmediateValue();
+      if (value == 0) {
+        info.append(" (default to 0x100)");
+      }
+    } else {
+      throw new IllegalStateException("Second operand should always be an immediate value.");
+    }
+    return new SetTimerDecrement(offset, ea.getBytes(), info.toString());
   }
 
   private static Opcode op_2113(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup22.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup22.java
@@ -50,121 +50,105 @@ public class OpcodeGroup22 {
   private static Opcode op_2200(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2201(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2202(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2203(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2204(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2205(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_220B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_220C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(12);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_220D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(12);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_220E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_220F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2210(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2211(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(12);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2212(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(12);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2213(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2214(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2215(ByteStream bs) throws IOException {
@@ -174,12 +158,11 @@ public class OpcodeGroup22 {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     baos.write(ea.getBytes());
-    String info = String.format(" %s", ea.getDescription());
     baos.write(bs.readBytes(8));
     for (int i = 0; i < num; i++) {
       baos.write(bs.readBytes(12));
     }
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 
   private static Opcode op_2216(ByteStream bs) throws IOException {
@@ -189,99 +172,87 @@ public class OpcodeGroup22 {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     baos.write(ea.getBytes());
-    String info = String.format(" %s", ea.getDescription());
     baos.write(bs.readBytes(8));
     for (int i = 0; i < num; i++) {
       baos.write(bs.readBytes(12));
     }
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 
   private static Opcode op_221E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_221F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2220(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2221(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2222(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2223(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2224(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2225(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2227(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2228(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2229(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup26.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup26.java
@@ -190,71 +190,61 @@ public class OpcodeGroup26 {
   private static Opcode op_2619(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2634(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26C0(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26C4(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26CC(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26E8(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26EB(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26F2(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26F6(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_26F9(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup27.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup27.java
@@ -48,62 +48,54 @@ public class OpcodeGroup27 {
   private static Opcode op_2700(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2702(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2703(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2704(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2706(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2707(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2708(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2709(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_270A(ByteStream bs) throws IOException {
@@ -114,7 +106,7 @@ public class OpcodeGroup27 {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     if (flag > 2) {
       SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-      info += String.format(" %s", ea.getDescription());
+      info = ea.getDescription();
       baos.write(ea.getBytes());
     }
     byte[] bytes = new byte[8];
@@ -128,149 +120,130 @@ public class OpcodeGroup27 {
   private static Opcode op_270B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_270C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_270E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_270F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2710(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2711(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2712(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2714(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2715(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2716(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2717(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2718(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2719(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_271A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_272C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_272D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2731(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2732(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2780(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2A.java
@@ -321,10 +321,10 @@ public class OpcodeGroup2A {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(ea.getDescription());
     SEQ_RegCMD1 ea2 = SEQ_RegCMD1.get(bs);
     baos.write(ea2.getBytes());
-    info.append("; ");
+    StringBuilder info = new StringBuilder(ea.getDescription());
+    info.append(", ");
     info.append(ea2.getDescription());
     baos.write(bs.readBytes(4));
     return new UnknownOpcode(offset, baos.toByteArray(), info.toString());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2A.java
@@ -41,7 +41,7 @@ public class OpcodeGroup2A {
   private static Opcode op_2A00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
+    StringBuilder info = new StringBuilder(ea.getDescription());
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
     byte[] flags = bs.readBytes(4);
@@ -50,7 +50,7 @@ public class OpcodeGroup2A {
     bb.put(flags[2]);
     bb.put(flags[3]);
     short pointerIndex = bb.getShort(0);
-    info += String.format("; with flag 0x%X", pointerIndex);
+    info.append(String.format("; with flag 0x%X", pointerIndex));
     switch (pointerIndex) {
       case 0x0:
       case 0x4:
@@ -235,7 +235,7 @@ public class OpcodeGroup2A {
             0x80212868 + flagOffset);
         throw new IllegalStateException(message);
     }
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), info.toString());
   }
 
   private static Opcode op_2A01(ByteStream bs) throws IOException {
@@ -243,7 +243,6 @@ public class OpcodeGroup2A {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    String info = String.format(" %s", ea.getDescription());
     byte[] flagBytes = bs.readBytes(4);
     baos.write(flagBytes);
     int flags = ByteUtils.toInt32(flagBytes);
@@ -314,7 +313,7 @@ public class OpcodeGroup2A {
             0x80212bb0 + pointerOffset);
         throw new IllegalStateException(message);
     }
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 
   private static Opcode op_2A02(ByteStream bs) throws IOException {
@@ -322,60 +321,55 @@ public class OpcodeGroup2A {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     baos.write(ea.getBytes());
-    String info = String.format(" %s", ea.getDescription());
+    StringBuilder info = new StringBuilder(ea.getDescription());
     SEQ_RegCMD1 ea2 = SEQ_RegCMD1.get(bs);
     baos.write(ea2.getBytes());
-    info += String.format("; %s", ea2.getDescription());
+    info.append("; ");
+    info.append(ea2.getDescription());
     baos.write(bs.readBytes(4));
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), info.toString());
   }
 
   private static Opcode op_2A0B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xc);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A0C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x14);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A0F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A10(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A11(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A14(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A15(ByteStream bs) throws IOException {
@@ -383,7 +377,7 @@ public class OpcodeGroup2A {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -396,31 +390,27 @@ public class OpcodeGroup2A {
   private static Opcode op_2A16(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_2A19(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A1A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_2A1B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup2B.java
@@ -25,7 +25,7 @@ public class OpcodeGroup2B {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -38,7 +38,6 @@ public class OpcodeGroup2B {
   public static Opcode op_2B01(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup31.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup31.java
@@ -31,42 +31,37 @@ public class OpcodeGroup31 {
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String text = SeqHelper.getString(textBytes);
-    String info = String.format(" with text \"%s\"", text);
+    String info = String.format("with text \"%s\"", text);
     return new UnknownOpcode(offset, baos.toByteArray(), info);
   }
 
   private static Opcode op_3101(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_3103(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_3106(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_310B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_311B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup34.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup34.java
@@ -22,7 +22,6 @@ public class OpcodeGroup34 {
   private static Opcode op_340D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup36.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup36.java
@@ -34,7 +34,7 @@ public class OpcodeGroup36 {
     baos.write(bs.readBytes(4));
     byte[] firstWord = bs.readBytes(4);
     baos.write(firstWord);
-    StringBuilder info = new StringBuilder(String.format(" Use index 0x%x", ByteUtils.toInt32(firstWord)));
+    StringBuilder info = new StringBuilder(String.format("Use index 0x%x", ByteUtils.toInt32(firstWord)));
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -50,7 +50,7 @@ public class OpcodeGroup36 {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
     baos.write(bs.readBytes(4));
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -63,9 +63,8 @@ public class OpcodeGroup36 {
   public static Opcode op_3608(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode seqInit(ByteStream bs) throws IOException {
@@ -73,7 +72,7 @@ public class OpcodeGroup36 {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
-    StringBuilder info = new StringBuilder(String.format(" %s", ea.getDescription()));
+    StringBuilder info = new StringBuilder(ea.getDescription());
     byte[] textBytes = SeqHelper.readString(bs);
     baos.write(textBytes);
     String fileName = SeqHelper.getString(textBytes);
@@ -86,15 +85,13 @@ public class OpcodeGroup36 {
   public static Opcode op_360C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_360D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3E.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3E.java
@@ -25,54 +25,48 @@ public class OpcodeGroup3E {
   private static Opcode op_3E00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 
   private static Opcode op_3E01(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 
   private static Opcode op_3E02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 
   private static Opcode op_3E03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 
   private static Opcode op_3E04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(8);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 
   private static Opcode op_3E05(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
     byte[] fullBytes = Bytes.concat(ea.getBytes(), lastWord);
-    return new UnknownOpcode(offset, fullBytes, info);
+    return new UnknownOpcode(offset, fullBytes, ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup40.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup40.java
@@ -33,36 +33,31 @@ public class OpcodeGroup40 {
   private static Opcode op_4003(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x20);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_400D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_401E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_401F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_4020(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup43.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup43.java
@@ -22,28 +22,24 @@ public class OpcodeGroup43 {
   public static Opcode op_4300(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4301(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4303(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4305(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup44.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup44.java
@@ -22,15 +22,13 @@ public class OpcodeGroup44 {
   public static Opcode op_4400(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4401(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup46.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup46.java
@@ -30,70 +30,61 @@ public class OpcodeGroup46 {
   private static Opcode op_4602(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4603(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_4604(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4605(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4606(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4607(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4608(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_4609(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_460A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x18);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup47.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup47.java
@@ -52,7 +52,7 @@ public class OpcodeGroup47 {
     baos.write(ea.getBytes());
     baos.write(bs.readBytes(0x8));
     int structOffset = bs.readWord();
-    String info = String.format(" %s; binary data at offset 0x%X", ea.getDescription(), structOffset);
+    String info = String.format("%s; binary data at offset 0x%X", ea.getDescription(), structOffset);
     baos.write(ByteUtils.fromInt32(structOffset));
     baos.write(bs.readBytes(0x8));
     return new UnknownOpcode(offset, baos.toByteArray(), info);
@@ -61,37 +61,32 @@ public class OpcodeGroup47 {
   public static Opcode op_4706(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4707(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_470A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_4712(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_471F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup49.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup49.java
@@ -30,7 +30,6 @@ public class OpcodeGroup49 {
   public static Opcode op_4909(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     baos.write(ea.getBytes());
     Operand operandOne = ea.getFirstOperand();
@@ -58,6 +57,6 @@ public class OpcodeGroup49 {
     } else {
       throw new IllegalStateException("This operand is not yet supported: " + operandOne);
     }
-    return new UnknownOpcode(offset, baos.toByteArray(), info);
+    return new UnknownOpcode(offset, baos.toByteArray(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4A.java
@@ -22,16 +22,14 @@ public class OpcodeGroup4A {
   private static Opcode op_4A00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_4A03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4B.java
@@ -24,22 +24,19 @@ public class OpcodeGroup4B {
   private static Opcode op_4B04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_4B05(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_4B07(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4C.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4C.java
@@ -42,127 +42,111 @@ public class OpcodeGroup4C {
   public static Opcode op_4C00(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C01(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C02(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C05(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C06(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C07(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C08(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C09(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C0A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C0B(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C0E(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C13(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C14(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(8);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_4C24(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4D.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4D.java
@@ -18,7 +18,6 @@ public class OpcodeGroup4D {
   public static Opcode op_4D03(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup50.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup50.java
@@ -29,29 +29,25 @@ public class OpcodeGroup50 {
   public static Opcode op_5005(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   public static Opcode op_5008(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_5009(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   public static Opcode op_500D(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup55.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup55.java
@@ -31,82 +31,71 @@ public class OpcodeGroup55 {
   private static Opcode op_5500(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x10);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_5501(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_5502(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_5505(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_5506(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_5507(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0x14);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_5508(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_5520(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(0xC);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_5580(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_5581(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] bytes = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
   private static Opcode op_5582(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup56.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup56.java
@@ -19,7 +19,6 @@ public class OpcodeGroup56 {
   public static Opcode op_5620(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
-    String info = String.format(" %s", ea.getDescription());
-    return new UnknownOpcode(offset, ea.getBytes(), info);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
@@ -65,8 +65,7 @@ public class OpcodeGroup61 {
   private static Opcode op_6102(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
-    String info = String.format(" %s", ea.getDescription());
     byte[] lastWord = bs.readBytes(4);
-    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), lastWord), info);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), lastWord), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class ActionID implements Opcode {
 
+  private final static String MNEMONIC = "Action ID";
   private final int offset;
   private final byte[] bytes;
   private final int actionId;
@@ -72,7 +73,7 @@ public class ActionID implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | Action ID 0x%X at offset 0x%X %s%s", offset, actionId, actionOffset, formatRawBytes(bytes), info);
+    return String.format("%05X | %s 0x%X at offset 0x%X %s%s", offset, MNEMONIC, actionId, actionOffset, formatRawBytes(bytes), info);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
@@ -61,6 +61,10 @@ public class ActionID implements Opcode {
     }
   }
 
+  public int getActionOffset() {
+    return actionOffset;
+  }
+
   @Override
   public int getOffset() {
     return offset;

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ActionID.java
@@ -81,8 +81,10 @@ public class ActionID implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", actionOffset);
     return div(attrs(id))
-        .with(span(String.format("%05X | Action ID 0x%X at offset ", offset, actionId)))
+        .withText(String.format("%05X | Action ID 0x%X at offset ", offset, actionId))
         .with(a(String.format("0x%X", actionOffset)).withHref(dest))
-        .with(span(String.format(" %s%s", formatRawBytes(bytes), info)));
+        .withText(" ")
+        .with(formatRawBytesHTML(bytes))
+        .withText(String.format(" %s", info));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
@@ -29,7 +29,7 @@ public class Add implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | add %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | add %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Add implements Opcode {
 
+  private final static String MNEMONIC = "add";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Add implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | add %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Add.java
@@ -36,6 +36,8 @@ public class Add implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class And implements Opcode {
 
+  private final static String MNEMONIC = "and";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class And implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | and %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
@@ -36,6 +36,8 @@ public class And implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/And.java
@@ -29,7 +29,7 @@ public class And implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | and %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | and %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Andws implements Opcode {
 
+  private final static String MNEMONIC = "andws";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Andws implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | andws %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
@@ -29,7 +29,7 @@ public class Andws implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | andws %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | andws %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Andws.java
@@ -36,6 +36,8 @@ public class Andws implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
@@ -35,7 +35,7 @@ public class BinaryData implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | binary data, 0x%x bytes %s%s", offset, bytes.length, formatRawBytes(bytes), info);
+    return String.format("%05X | binary data, 0x%x bytes %s %s", offset, bytes.length, formatRawBytes(bytes), info);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BinaryData implements Opcode {
 
+  private final static String MNEMONIC = "binary_data";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -35,7 +36,7 @@ public class BinaryData implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | binary data, 0x%x bytes %s %s", offset, bytes.length, info, formatRawBytes(bytes));
+    return String.format("%05X | %s 0x%X bytes %s %s", offset, MNEMONIC, bytes.length, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BinaryData.java
@@ -35,7 +35,7 @@ public class BinaryData implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | binary data, 0x%x bytes %s %s", offset, bytes.length, formatRawBytes(bytes), info);
+    return String.format("%05X | binary data, 0x%x bytes %s %s", offset, bytes.length, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
@@ -41,8 +41,9 @@ public class Branch implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | b ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01320000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
@@ -40,7 +40,7 @@ public class Branch implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | b ", offset)).attr("class=\"b\""))
+        .with(span(String.format("%05X | b ", offset)))
         .with(a(String.format("0x%X", destination)).withHref(dest))
         .with(span(String.format(" {01320000 %08X}", destination)));
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Branch.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 public class Branch implements Opcode {
 
+  private final static String MNEMONIC = "b";
   private final int offset;
   private final int destination;
 
@@ -32,7 +33,7 @@ public class Branch implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | b 0x%X {01320000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01320000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override
@@ -43,10 +44,5 @@ public class Branch implements Opcode {
         .with(span(String.format("%05X | b ", offset)))
         .with(a(String.format("0x%X", destination)).withHref(dest))
         .with(span(String.format(" {01320000 %08X}", destination)));
-  }
-
-  @Override
-  public Optional<String> description() {
-    return Optional.of("Unconditional branch to offset.");
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchDecrementNotZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchDecrementNotZero.java
@@ -40,8 +40,9 @@ public class BranchDecrementNotZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bdnz ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {013B0000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchDecrementNotZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchDecrementNotZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchDecrementNotZero implements Opcode {
 
+  private final static String MNEMONIC = "bdnz";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchDecrementNotZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bdnz 0x%X {013B0000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {013B0000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZero.java
@@ -40,8 +40,9 @@ public class BranchEqualToZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | beqz ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01330000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchEqualToZero implements Opcode {
 
+  private final static String MNEMONIC = "beqz";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchEqualToZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | beqz 0x%X {01330000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01330000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZeroLink.java
@@ -40,8 +40,9 @@ public class BranchEqualToZeroLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | beqzal ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {013D0000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchEqualToZeroLink.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchEqualToZeroLink implements Opcode {
 
+  private final static String MNEMONIC = "beqzal";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchEqualToZeroLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | beqzal 0x%X {013D0000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {013D0000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanOrEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanOrEqualToZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchGreaterThanOrEqualToZero implements Opcode {
 
+  private final static String MNEMONIC = "bgez";
   private final int offset;
   private final int destination;
   private final byte secondByte;
@@ -39,7 +40,7 @@ public class BranchGreaterThanOrEqualToZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bgez 0x%X {01%02X0000 %08X}", offset, destination, secondByte, destination);
+    return String.format("%05X | %s 0x%X {01%02X0000 %08X}", offset, MNEMONIC, destination, secondByte, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanOrEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanOrEqualToZero.java
@@ -48,8 +48,9 @@ public class BranchGreaterThanOrEqualToZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bgez ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01%02X0000 %08X}", secondByte, destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchGreaterThanZero implements Opcode {
 
+  private final static String MNEMONIC = "bgtz";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchGreaterThanZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bgtz 0x%X {01350000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01350000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchGreaterThanZero.java
@@ -40,8 +40,9 @@ public class BranchGreaterThanZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bgtz ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01350000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanEqualZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanEqualZeroLink.java
@@ -40,8 +40,9 @@ public class BranchLessThanEqualZeroLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | blezal ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01420000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanEqualZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanEqualZeroLink.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLessThanEqualZeroLink implements Opcode {
 
+  private final static String MNEMONIC = "blezal";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchLessThanEqualZeroLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blezal 0x%X {01420000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01420000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanOrEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanOrEqualToZero.java
@@ -40,8 +40,9 @@ public class BranchLessThanOrEqualToZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | blez ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01380000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanOrEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanOrEqualToZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLessThanOrEqualToZero implements Opcode {
 
+  private final static String MNEMONIC = "blez";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchLessThanOrEqualToZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blez 0x%X {01380000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01380000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLessThanZero implements Opcode {
 
+  private final static String MNEMONIC = "bltz";
   private final int offset;
   private final int destination;
   private final byte secondByte;
@@ -39,7 +40,7 @@ public class BranchLessThanZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bltz 0x%X {01%02X0000 %08X}", offset, destination, secondByte, destination);
+    return String.format("%05X | %s 0x%X {01%02X0000 %08X}", offset, MNEMONIC, destination, secondByte, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZero.java
@@ -48,8 +48,9 @@ public class BranchLessThanZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bltz ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01%02X0000 %08X}", secondByte, destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZeroLink.java
@@ -40,8 +40,9 @@ public class BranchLessThanZeroLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bltzal ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01410000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLessThanZeroLink.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLessThanZeroLink implements Opcode {
 
+  private final static String MNEMONIC = "bltzal";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchLessThanZeroLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bltzal 0x%X {01410000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01410000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
@@ -40,8 +40,9 @@ public class BranchLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bl ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {013C0000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
@@ -20,6 +20,10 @@ public class BranchLink implements Opcode {
     this.destination = destination;
   }
 
+  public int getDestination() {
+    return destination;
+  }
+
   @Override
   public int getOffset() {
     return offset;

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
@@ -39,7 +39,7 @@ public class BranchLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bl ", offset)).attr("class=\"bl\""))
+        .with(span(String.format("%05X | bl ", offset)))
         .with(a(String.format("0x%X", destination)).withHref(dest))
         .with(span(String.format(" {013C0000 %08X}", destination)));
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLink.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLink implements Opcode {
 
+  private final static String MNEMONIC = "bl";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bl 0x%X {013C0000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {013C0000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturn.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturn.java
@@ -32,6 +32,8 @@ public class BranchLinkReturn implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturn.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturn.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturn implements Opcode {
 
+  private final static String MNEMONIC = "blr";
   private final int offset;
 
   public BranchLinkReturn(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturn implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blr {01450000}", offset);
+    return String.format("%05X | %s {01450000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnEqualZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnEqualZero implements Opcode {
 
+  private final static String MNEMONIC = "blreqz";
   private final int offset;
 
   public BranchLinkReturnEqualZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnEqualZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blreqz {01450000}", offset);
+    return String.format("%05X | %s {01450000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnEqualZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnEqualZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanEqualZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnGreaterThanEqualZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanEqualZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnGreaterThanEqualZero implements Opcode {
 
+  private final static String MNEMONIC = "blrgez";
   private final int offset;
 
   public BranchLinkReturnGreaterThanEqualZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnGreaterThanEqualZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blrgez {01490000}", offset);
+    return String.format("%05X | %s {01490000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnGreaterThanZero implements Opcode {
 
+  private final static String MNEMONIC = "blrgtz";
   private final int offset;
 
   public BranchLinkReturnGreaterThanZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnGreaterThanZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blrgtz {01480000}", offset);
+    return String.format("%05X | %s {01480000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnGreaterThanZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnGreaterThanZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanEqualZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnLessThanEqualZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanEqualZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnLessThanEqualZero implements Opcode {
 
+  private final static String MNEMONIC = "blrlez";
   private final int offset;
 
   public BranchLinkReturnLessThanEqualZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnLessThanEqualZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blrlez {014B0000}", offset);
+    return String.format("%05X | %s {014B0000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnLessThanZero implements Opcode {
 
+  private final static String MNEMONIC = "blrltz";
   private final int offset;
 
   public BranchLinkReturnLessThanZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnLessThanZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blrltz {014A0000}", offset);
+    return String.format("%05X | %s {014A0000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnLessThanZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnLessThanZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnNotEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnNotEqualZero.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchLinkReturnNotEqualZero implements Opcode {
 
+  private final static String MNEMONIC = "blrnez";
   private final int offset;
 
   public BranchLinkReturnNotEqualZero(int offset) {
@@ -25,7 +26,7 @@ public class BranchLinkReturnNotEqualZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | blrnez {01450000}", offset);
+    return String.format("%05X | %s {01450000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnNotEqualZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchLinkReturnNotEqualZero.java
@@ -32,6 +32,8 @@ public class BranchLinkReturnNotEqualZero implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualToZero.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchNotEqualToZero implements Opcode {
 
+  private final static String MNEMONIC = "bnez";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchNotEqualToZero implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bnez 0x%X {01340000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {01340000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualToZero.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualToZero.java
@@ -40,8 +40,9 @@ public class BranchNotEqualToZero implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bnez ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {01340000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
@@ -39,7 +39,7 @@ public class BranchNotEqualZeroLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bnezal ", offset)).attr("class=\"bnezal\""))
+        .with(span(String.format("%05X | bnezal ", offset)))
         .with(a(String.format("0x%X", destination)).withHref(dest))
         .with(span(String.format(" {013E0000 %08X}", destination)));
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
@@ -40,8 +40,9 @@ public class BranchNotEqualZeroLink implements Opcode {
     String id = String.format("#%X", offset);
     String dest = String.format("#%X", destination);
     return div(attrs(id))
-        .with(span(String.format("%05X | bnezal ", offset)))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
         .with(a(String.format("0x%X", destination)).withHref(dest))
-        .with(span(String.format(" {013E0000 %08X}", destination)));
+        .withText(" ")
+        .with(formatRawBytesHTML(getBytes()));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchNotEqualZeroLink.java
@@ -11,6 +11,7 @@ import j2html.tags.ContainerTag;
 
 public class BranchNotEqualZeroLink implements Opcode {
 
+  private final static String MNEMONIC = "bnezal";
   private final int offset;
   private final int destination;
 
@@ -31,7 +32,7 @@ public class BranchNotEqualZeroLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | bnezal 0x%X {013E0000 %08X}", offset, destination, destination);
+    return String.format("%05X | %s 0x%X {013E0000 %08X}", offset, MNEMONIC, destination, destination);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTable.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTable.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
+import java.util.List;
 
 public class BranchTable implements Opcode {
 
@@ -13,9 +14,9 @@ public class BranchTable implements Opcode {
   private final int offset;
   private final byte[] bytes;
   private final String info;
-  private final int[] offsets;
+  private final List<Integer> offsets;
 
-  public BranchTable(int offset, byte[] bytes, String info, int[] offsets) {
+  public BranchTable(int offset, byte[] bytes, String info, List<Integer> offsets) {
     this.offset = offset;
     this.bytes = bytes;
     this.info = info;
@@ -34,14 +35,14 @@ public class BranchTable implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.length, MNEMONIC, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.size(), MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
     DivTag div =  div(attrs(id))
-        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.length));
+        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.size()));
     for (int offset : offsets) {
       String dest = String.format("#%X", offset);
       div.withText(" ");

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTable.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTable.java
@@ -1,0 +1,53 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+import j2html.tags.specialized.DivTag;
+
+public class BranchTable implements Opcode {
+
+  private final static String MNEMONIC = "branch_table";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+  private final int[] offsets;
+
+  public BranchTable(int offset, byte[] bytes, String info, int[] offsets) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+    this.offsets = offsets;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.length, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    DivTag div =  div(attrs(id))
+        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.length));
+    for (int offset : offsets) {
+      String dest = String.format("#%X", offset);
+      div.withText(" ");
+      div.with(a(String.format("0x%X", offset)).withHref(dest));
+    }
+    div.withText(" ");
+    return div.with(formatRawBytesHTML(getBytes()));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTableLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTableLink.java
@@ -1,0 +1,53 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+import j2html.tags.specialized.DivTag;
+
+public class BranchTableLink implements Opcode {
+
+  private final static String MNEMONIC = "branch_table_link";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+  private final int[] offsets;
+
+  public BranchTableLink(int offset, byte[] bytes, String info, int[] offsets) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+    this.offsets = offsets;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.length, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    DivTag div =  div(attrs(id))
+        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.length));
+    for (int offset : offsets) {
+      String dest = String.format("#%X", offset);
+      div.withText(" ");
+      div.with(a(String.format("0x%X", offset)).withHref(dest));
+    }
+    div.withText(" ");
+    return div.with(formatRawBytesHTML(getBytes()));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTableLink.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/BranchTableLink.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
+import java.util.List;
 
 public class BranchTableLink implements Opcode {
 
@@ -13,9 +14,9 @@ public class BranchTableLink implements Opcode {
   private final int offset;
   private final byte[] bytes;
   private final String info;
-  private final int[] offsets;
+  private final List<Integer> offsets;
 
-  public BranchTableLink(int offset, byte[] bytes, String info, int[] offsets) {
+  public BranchTableLink(int offset, byte[] bytes, String info, List<Integer> offsets) {
     this.offset = offset;
     this.bytes = bytes;
     this.info = info;
@@ -34,14 +35,14 @@ public class BranchTableLink implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.length, MNEMONIC, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s (%d branches)", offset, offsets.size(), MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
     DivTag div =  div(attrs(id))
-        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.length));
+        .withText(String.format("%05X | %s %s (%d branches):", offset, MNEMONIC, info, offsets.size()));
     for (int offset : offsets) {
       String dest = String.format("#%X", offset);
       div.withText(" ");

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
@@ -36,6 +36,8 @@ public class ByteMovc implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
@@ -29,7 +29,7 @@ public class ByteMovc implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | b_movc %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | b_movc %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ByteMovc.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ByteMovc implements Opcode {
 
+  private final static String MNEMONIC = "b_movc";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ByteMovc implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | b_movc %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/CharacterUpdate.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/CharacterUpdate.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class CharacterUpdate implements Opcode {
+
+  private final static String MNEMONIC = "chr_update";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public CharacterUpdate(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/CharacterUpdate2.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/CharacterUpdate2.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class CharacterUpdate2 implements Opcode {
+
+  private final static String MNEMONIC = "chr_update_2";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public CharacterUpdate2(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
@@ -29,7 +29,7 @@ public class Combo implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | combo_list: %s%s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | combo_list: %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
@@ -36,6 +36,8 @@ public class Combo implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s: %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Combo.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Combo implements Opcode {
 
+  private final static String MNEMONIC = "combo_list";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Combo implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | combo_list: %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s: %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
@@ -29,7 +29,7 @@ public class Decrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | dec %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | dec %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
@@ -36,6 +36,8 @@ public class Decrement implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Decrement.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Decrement implements Opcode {
 
+  private final static String MNEMONIC = "dec";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Decrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | dec %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
@@ -36,6 +36,8 @@ public class Divide implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Divide implements Opcode {
 
+  private final static String MNEMONIC = "div";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Divide implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | div %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Divide.java
@@ -29,7 +29,7 @@ public class Divide implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | div %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | div %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/End.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/End.java
@@ -6,12 +6,12 @@ import static j2html.TagCreator.span;
 
 import j2html.tags.ContainerTag;
 
-public class SoftReset implements Opcode {
+public class End implements Opcode {
 
-  private final static String MNEMONIC = "soft_reset";
+  private final static String MNEMONIC = "end";
   private final int offset;
 
-  public SoftReset(int offset) {
+  public End(int offset) {
     this.offset = offset;
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FlagOperation.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FlagOperation.java
@@ -35,6 +35,8 @@ public class FlagOperation implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
@@ -29,7 +29,7 @@ public class FloatCompare implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mov %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | f_mov %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class FloatCompare implements Opcode {
 
+  private final static String MNEMONIC = "f_mov";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class FloatCompare implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mov %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatCompare.java
@@ -36,6 +36,8 @@ public class FloatCompare implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
@@ -36,6 +36,8 @@ public class FloatDivide implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class FloatDivide implements Opcode {
 
+  private final static String MNEMONIC = "f_div";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class FloatDivide implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_div %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatDivide.java
@@ -29,7 +29,7 @@ public class FloatDivide implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_div %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | f_div %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
@@ -29,7 +29,7 @@ public class FloatMove implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mov %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | f_mov %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class FloatMove implements Opcode {
 
+  private final static String MNEMONIC = "f_mov";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class FloatMove implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mov %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMove.java
@@ -36,6 +36,8 @@ public class FloatMove implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class FloatMultiply implements Opcode {
 
+  private final static String MNEMONIC = "f_mul";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class FloatMultiply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mul %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
@@ -36,6 +36,8 @@ public class FloatMultiply implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatMultiply.java
@@ -29,7 +29,7 @@ public class FloatMultiply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_mul %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | f_mul %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
@@ -29,7 +29,7 @@ public class FloatSubtract implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_sub %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | f_sub %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
@@ -36,6 +36,8 @@ public class FloatSubtract implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/FloatSubtract.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class FloatSubtract implements Opcode {
 
+  private final static String MNEMONIC = "f_sub";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class FloatSubtract implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | f_sub %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/HardReset.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/HardReset.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class HardReset implements Opcode {
 
+  private final static String MNEMONIC = "hard_reset";
   private final int offset;
 
   public HardReset(int offset) {
@@ -25,7 +26,7 @@ public class HardReset implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | hard_reset {00010000}", offset);
+    return String.format("%05X | %s {00010000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/HardReset.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/HardReset.java
@@ -2,6 +2,7 @@ package com.github.nicholasmoser.gnt4.seq.opcodes;
 
 import static j2html.TagCreator.attrs;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.span;
 
 import j2html.tags.ContainerTag;
 
@@ -32,6 +33,8 @@ public class HardReset implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(span("00010000").withClass("g"));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
@@ -29,7 +29,7 @@ public class Increment implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | inc %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | inc %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Increment implements Opcode {
 
+  private final static String MNEMONIC = "inc";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Increment implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | inc %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Increment.java
@@ -36,6 +36,8 @@ public class Increment implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
@@ -29,7 +29,7 @@ public class Movc implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | movc %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | movc %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
@@ -36,6 +36,8 @@ public class Movc implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movc.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Movc implements Opcode {
 
+  private final static String MNEMONIC = "movc";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Movc implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | movc %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Movr implements Opcode {
 
+  private final static String MNEMONIC = "movr";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Movr implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | movr %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
@@ -29,7 +29,7 @@ public class Movr implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | movr %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | movr %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Movr.java
@@ -36,6 +36,8 @@ public class Movr implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
@@ -36,6 +36,8 @@ public class Multiply implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
@@ -29,7 +29,7 @@ public class Multiply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | mul %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | mul %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Multiply.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Multiply implements Opcode {
 
+  private final static String MNEMONIC = "mul";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Multiply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | mul %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
@@ -29,7 +29,7 @@ public class Nimply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | nimply %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | nimply %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Nimply implements Opcode {
 
+  private final static String MNEMONIC = "nimply";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Nimply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | nimply %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Nimply.java
@@ -36,6 +36,8 @@ public class Nimply implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Opcode.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Opcode.java
@@ -1,7 +1,9 @@
 package com.github.nicholasmoser.gnt4.seq.opcodes;
 
+import static j2html.TagCreator.span;
+
 import j2html.tags.ContainerTag;
-import java.util.Optional;
+import j2html.tags.specialized.SpanTag;
 
 public interface Opcode {
 
@@ -24,7 +26,14 @@ public interface Opcode {
     return sb.toString();
   }
 
-  default Optional<String> description() {
-    return Optional.empty();
+  default SpanTag formatRawBytesHTML(byte[] bytes) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < bytes.length; i++) {
+      sb.append(String.format("%02X", bytes[i]));
+      if (i % 4 == 3 && i != bytes.length - 1) {
+        sb.append(' ');
+      }
+    }
+    return span(sb.toString()).withClass("g");
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Or implements Opcode {
 
+  private final static String MNEMONIC = "or";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Or implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | or %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
@@ -36,6 +36,8 @@ public class Or implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Or.java
@@ -29,7 +29,7 @@ public class Or implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | or %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | or %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
@@ -36,6 +36,8 @@ public class Pop implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
@@ -29,7 +29,7 @@ public class Pop implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | pop %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | pop %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Pop.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Pop implements Opcode {
 
+  private final static String MNEMONIC = "pop";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Pop implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | pop %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
@@ -29,7 +29,7 @@ public class Push implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | push %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | push %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Push implements Opcode {
 
+  private final static String MNEMONIC = "push";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Push implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | push %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Push.java
@@ -36,6 +36,8 @@ public class Push implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqLoadPrev.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqLoadPrev.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class SEQ_ReqLoadPrev implements Opcode {
+
+  private final static String MNEMONIC = "SEQ_ReqLoadPrev";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public SEQ_ReqLoadPrev(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqLoadPrev_I.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqLoadPrev_I.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class SEQ_ReqLoadPrev_I implements Opcode {
+
+  private final static String MNEMONIC = "SEQ_ReqLoadPrev_I";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public SEQ_ReqLoadPrev_I(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqSetPrev.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SEQ_ReqSetPrev.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class SEQ_ReqSetPrev implements Opcode {
+
+  private final static String MNEMONIC = "SEQ_ReqSetPrev";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public SEQ_ReqSetPrev(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SectionTitle.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SectionTitle.java
@@ -8,6 +8,7 @@ import j2html.tags.ContainerTag;
 
 public class SectionTitle implements Opcode {
 
+  private final static String MNEMONIC = "Section Title";
   private final int offset;
   private final byte[] bytes;
   private final String title;
@@ -34,7 +35,7 @@ public class SectionTitle implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | Section Title: %s %s", offset, title, formatRawBytes(bytes));
+    return String.format("%05X | %s: %s %s", offset, MNEMONIC, title, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SeqEditOpcode.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SeqEditOpcode.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public class SeqEditOpcode implements Opcode {
 
+  private final static String MNEMONIC = "Seq Edit";
   private final int offset;
   private final SeqEdit edit;
 
@@ -32,7 +33,7 @@ public class SeqEditOpcode implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | Seq Edit: %s %s", offset, edit.getName(), formatRawBytes(getBytes()));
+    return String.format("%05X | %s: %s %s", offset, MNEMONIC, edit.getName(), formatRawBytes(getBytes()));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SetTimerDecrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SetTimerDecrement.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class SetTimerDecrement implements Opcode {
+
+  private final static String MNEMONIC = "set_timer_decrement";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public SetTimerDecrement(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortAdd implements Opcode {
 
+  private final static String MNEMONIC = "s_add";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortAdd implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_add %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
@@ -36,6 +36,8 @@ public class ShortAdd implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAdd.java
@@ -29,7 +29,7 @@ public class ShortAdd implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_add %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_add %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
@@ -36,6 +36,8 @@ public class ShortAndWithStore implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortAndWithStore implements Opcode {
 
+  private final static String MNEMONIC = "s_andws";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortAndWithStore implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_andws %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortAndWithStore.java
@@ -29,7 +29,7 @@ public class ShortAndWithStore implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_andws %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_andws %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
@@ -29,7 +29,7 @@ public class ShortDecrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_dec %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_dec %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortDecrement implements Opcode {
 
+  private final static String MNEMONIC = "s_dec";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortDecrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_dec %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortDecrement.java
@@ -36,6 +36,8 @@ public class ShortDecrement implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortIncrement implements Opcode {
 
+  private final static String MNEMONIC = "s_inc";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortIncrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_inc %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
@@ -29,7 +29,7 @@ public class ShortIncrement implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_inc %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_inc %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortIncrement.java
@@ -36,6 +36,8 @@ public class ShortIncrement implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
@@ -36,6 +36,8 @@ public class ShortMove implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
@@ -29,7 +29,7 @@ public class ShortMove implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_mov %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_mov %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortMove.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortMove implements Opcode {
 
+  private final static String MNEMONIC = "s_mov";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortMove implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_mov %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
@@ -36,6 +36,8 @@ public class ShortNimply implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortNimply implements Opcode {
 
+  private final static String MNEMONIC = "s_nimply";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortNimply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_nimply %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortNimply.java
@@ -29,7 +29,7 @@ public class ShortNimply implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_nimply %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_nimply %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
@@ -36,6 +36,8 @@ public class ShortOr implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
@@ -29,7 +29,7 @@ public class ShortOr implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_or %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_or %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortOr.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortOr implements Opcode {
 
+  private final static String MNEMONIC = "s_or";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortOr implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_or %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortSubtract implements Opcode {
 
+  private final static String MNEMONIC = "s_sub";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortSubtract implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_sub %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
@@ -29,7 +29,7 @@ public class ShortSubtract implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_sub %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_sub %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtract.java
@@ -36,6 +36,8 @@ public class ShortSubtract implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
@@ -36,6 +36,8 @@ public class ShortSubtractWithStore implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class ShortSubtractWithStore implements Opcode {
 
+  private final static String MNEMONIC = "s_subws";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class ShortSubtractWithStore implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_subws %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/ShortSubtractWithStore.java
@@ -29,7 +29,7 @@ public class ShortSubtractWithStore implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | s_subws %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | s_subws %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SoftReset.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SoftReset.java
@@ -2,6 +2,7 @@ package com.github.nicholasmoser.gnt4.seq.opcodes;
 
 import static j2html.TagCreator.attrs;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.span;
 
 import j2html.tags.ContainerTag;
 
@@ -32,6 +33,8 @@ public class SoftReset implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s ", offset, MNEMONIC))
+        .with(span("00000000").withClass("g"));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SoftReset.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SoftReset.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class SoftReset implements Opcode {
 
+  private final static String MNEMONIC = "soft_reset";
   private final int offset;
 
   public SoftReset(int offset) {
@@ -25,7 +26,7 @@ public class SoftReset implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | soft_reset {00000000}", offset);
+    return String.format("%05X | %s {00000000}", offset, MNEMONIC);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
@@ -36,6 +36,8 @@ public class Sub implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
@@ -29,7 +29,7 @@ public class Sub implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | sub %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | sub %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Sub.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Sub implements Opcode {
 
+  private final static String MNEMONIC = "sub";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Sub implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | sub %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
@@ -29,7 +29,7 @@ public class Subws implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | subws %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | subws %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Subws implements Opcode {
 
+  private final static String MNEMONIC = "subws";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Subws implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | subws %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Subws.java
@@ -36,6 +36,8 @@ public class Subws implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 public class SynchronousTimer implements Opcode {
 
+  private final static String MNEMONIC = "sync_timer";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -32,7 +33,7 @@ public class SynchronousTimer implements Opcode {
   @Override
   public String toString() {
     int frames = ByteUtils.toInt32(Arrays.copyOfRange(bytes, 4, 8));
-    return String.format("%05X | sync_timer (%d frames) %s %s", offset, frames, info, formatRawBytes(bytes));
+    return String.format("%05X | %s (%d frames) %s %s", offset, MNEMONIC, frames, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
@@ -39,6 +39,9 @@ public class SynchronousTimer implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    int frames = ByteUtils.toInt32(Arrays.copyOfRange(bytes, 4, 8));
+    return div(attrs(id))
+        .withText(String.format("%05X | %s (%d frames) %s ", offset, MNEMONIC, frames, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimer.java
@@ -32,7 +32,7 @@ public class SynchronousTimer implements Opcode {
   @Override
   public String toString() {
     int frames = ByteUtils.toInt32(Arrays.copyOfRange(bytes, 4, 8));
-    return String.format("%05X | sync_timer (%d frames) %s %s", offset, frames, formatRawBytes(bytes), info);
+    return String.format("%05X | sync_timer (%d frames) %s %s", offset, frames, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 public class SynchronousTimerRun implements Opcode {
 
+  private final static String MNEMONIC = "sync_timer_run";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -31,7 +32,7 @@ public class SynchronousTimerRun implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | sync_timer_run %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
@@ -31,7 +31,7 @@ public class SynchronousTimerRun implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | sync_timer_run %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | sync_timer_run %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/SynchronousTimerRun.java
@@ -38,6 +38,8 @@ public class SynchronousTimerRun implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/TskExecFunc.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/TskExecFunc.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class TskExecFunc implements Opcode {
+
+  private final static String MNEMONIC = "TskExecFunc";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public TskExecFunc(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/TskSendMsg.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/TskSendMsg.java
@@ -1,0 +1,43 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class TskSendMsg implements Opcode {
+
+  private final static String MNEMONIC = "TskSendMsg";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public TskSendMsg(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
@@ -55,6 +55,8 @@ public class UnknownOpcode implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | op_%02X%02X %s ", offset, bytes[0], bytes[1], info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
@@ -49,7 +49,7 @@ public class UnknownOpcode implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | op_%02X%02X %s%s", offset, bytes[0], bytes[1], formatRawBytes(bytes), info);
+    return String.format("%05X | op_%02X%02X %s %s", offset, bytes[0], bytes[1], formatRawBytes(bytes), info);
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/UnknownOpcode.java
@@ -49,7 +49,7 @@ public class UnknownOpcode implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | op_%02X%02X %s %s", offset, bytes[0], bytes[1], formatRawBytes(bytes), info);
+    return String.format("%05X | op_%02X%02X %s %s", offset, bytes[0], bytes[1], info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
@@ -36,6 +36,8 @@ public class Xor implements Opcode {
   @Override
   public ContainerTag toHTML() {
     String id = String.format("#%X", offset);
-    return div(attrs(id)).withText(toString());
+    return div(attrs(id))
+        .withText(String.format("%05X | %s %s ", offset, MNEMONIC, info))
+        .with(formatRawBytesHTML(bytes));
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
@@ -7,6 +7,7 @@ import j2html.tags.ContainerTag;
 
 public class Xor implements Opcode {
 
+  private final static String MNEMONIC = "xor";
   private final int offset;
   private final byte[] bytes;
   private final String info;
@@ -29,7 +30,7 @@ public class Xor implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | xor %s %s", offset, info, formatRawBytes(bytes));
+    return String.format("%05X | %s %s %s", offset, MNEMONIC, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/Xor.java
@@ -29,7 +29,7 @@ public class Xor implements Opcode {
 
   @Override
   public String toString() {
-    return String.format("%05X | xor %s %s", offset, formatRawBytes(bytes), info);
+    return String.format("%05X | xor %s %s", offset, info, formatRawBytes(bytes));
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/GPROperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/GPROperand.java
@@ -34,6 +34,6 @@ public class GPROperand implements Operand {
   @Override
   public String toString() {
     String prefix = pointer ? "" : "*";
-    return String.format("EA: %sgpr%d%s", prefix, index, infoBuilder);
+    return String.format("%sgpr%d%s", prefix, index, infoBuilder);
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/GlobalOperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/GlobalOperand.java
@@ -52,6 +52,6 @@ public class GlobalOperand implements Operand {
 
   @Override
   public String toString() {
-    return String.format("EA: %s%s", getName(), infoBuilder);
+    return String.format("%s%s", getName(), infoBuilder);
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/ImmediateOperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/ImmediateOperand.java
@@ -27,6 +27,6 @@ public class ImmediateOperand implements Operand {
 
   @Override
   public String toString() {
-    return String.format("EA: Immediate value offset 0x%x (0x%08x)%s", offset, word, infoBuilder);
+    return String.format("Immediate value offset 0x%x (0x%08x)%s", offset, word, infoBuilder);
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/ImmediateOperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/ImmediateOperand.java
@@ -27,6 +27,6 @@ public class ImmediateOperand implements Operand {
 
   @Override
   public String toString() {
-    return String.format("Immediate value offset 0x%x (0x%08x)%s", offset, word, infoBuilder);
+    return String.format("0x%X%s", word, infoBuilder);
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/SeqOperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/SeqOperand.java
@@ -34,6 +34,6 @@ public class SeqOperand implements Operand {
   @Override
   public String toString() {
     String prefix = pointer ? "" : "*";
-    return String.format("EA: %sseq_p_sp->field_0x%02x%s", prefix, index, infoBuilder);
+    return String.format("%sseq_p_sp->field_0x%02x%s", prefix, index, infoBuilder);
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/SeqOperand.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/operands/SeqOperand.java
@@ -34,6 +34,6 @@ public class SeqOperand implements Operand {
   @Override
   public String toString() {
     String prefix = pointer ? "" : "*";
-    return String.format("%sseq_p_sp->field_0x%02x%s", prefix, index, infoBuilder);
+    return String.format("%sseq_p_sp->field_0x%02x%s", prefix, index * 4, infoBuilder);
   }
 }

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
@@ -30,7 +30,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr19", ea.getDescription());
+    assertEquals("gpr19", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -52,7 +52,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr3", ea.getDescription());
+    assertEquals("gpr3", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -74,7 +74,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x0a", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0a", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -99,7 +99,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x0e", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0e", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -121,7 +121,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: CONTROLLERS", ea.getDescription());
+    assertEquals("CONTROLLERS", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -144,7 +144,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: SAVE_DATA", ea.getDescription());
+    assertEquals("SAVE_DATA", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -168,7 +168,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x4 (0x00000100)", ea.getDescription());
+    assertEquals("Immediate value offset 0x4 (0x00000100)", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -190,7 +190,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x4 (0x00000100)", ea.getDescription());
+    assertEquals("Immediate value offset 0x4 (0x00000100)", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -212,7 +212,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *gpr0 + *gpr23 + 0000", ea.getDescription());
+    assertEquals("*gpr0 + *gpr23 + 0000", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -234,7 +234,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *seq_p_sp->field_0xbc + *gpr23 + 0000", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0xbc + *gpr23 + 0000", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -256,7 +256,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: DISPLAY + *seq_p_sp->field_0x90 + 0000", ea.getDescription());
+    assertEquals("DISPLAY + *seq_p_sp->field_0x90 + 0000", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -281,7 +281,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{(byte) 0x02, 0x06, 0x00, (byte) 0xbe, 0x12, 0x34, 0x00, 0x04},
         ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
+    assertEquals("Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -306,7 +306,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{(byte) 0x02, 0x06, 0x00, (byte) 0xbf, 0x12, 0x34, 0x00, 0x04},
         ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
+    assertEquals("Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -329,7 +329,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *gpr2 + offset 0x00000000", ea.getDescription());
+    assertEquals("*gpr2 + offset 0x00000000", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -351,7 +351,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *gpr19 + offset 0x00000004", ea.getDescription());
+    assertEquals("*gpr19 + offset 0x00000004", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -373,7 +373,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *seq_p_sp->field_0xa0 + offset 0x0000005C", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0xa0 + offset 0x0000005C", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -395,7 +395,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *seq_p_sp->field_0x98 + offset 0x00000020", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000020", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -417,7 +417,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: HITBOX_IDENTITY_MATRIX + offset 0x00000060", ea.getDescription());
+    assertEquals("HITBOX_IDENTITY_MATRIX + offset 0x00000060", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -440,7 +440,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: SAVE_DATA + offset 0x000001B6", ea.getDescription());
+    assertEquals("SAVE_DATA + offset 0x000001B6", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -464,7 +464,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7e, 0x00, 0x00, 0x10, 0x00}, ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x8 (0x00000000) + offset 0x00001000",
+    assertEquals("Immediate value offset 0x8 (0x00000000) + offset 0x00001000",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -489,7 +489,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7f, 0x00, 0x00, 0x00, (byte) 0x89},
         ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x8 (0x0f0e003f) + offset 0x00000089",
+    assertEquals("Immediate value offset 0x8 (0x0f0e003f) + offset 0x00000089",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
@@ -168,7 +168,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("Immediate value offset 0x4 (0x00000100)", ea.getDescription());
+    assertEquals("0x100", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -190,7 +190,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("Immediate value offset 0x4 (0x00000100)", ea.getDescription());
+    assertEquals("0x100", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -281,7 +281,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{(byte) 0x02, 0x06, 0x00, (byte) 0xbe, 0x12, 0x34, 0x00, 0x04},
         ea.getBytes());
-    assertEquals("Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
+    assertEquals("0x3000 + *gpr4 + 1234",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -306,7 +306,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{(byte) 0x02, 0x06, 0x00, (byte) 0xbf, 0x12, 0x34, 0x00, 0x04},
         ea.getBytes());
-    assertEquals("Immediate value offset 0x8 (0x00003000) + *gpr4 + 1234",
+    assertEquals("0x3000 + *gpr4 + 1234",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -464,7 +464,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7e, 0x00, 0x00, 0x10, 0x00}, ea.getBytes());
-    assertEquals("Immediate value offset 0x8 (0x00000000) + offset 0x00001000",
+    assertEquals("0x0 + offset 0x00001000",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -489,7 +489,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7f, 0x00, 0x00, 0x00, (byte) 0x89},
         ea.getBytes());
-    assertEquals("Immediate value offset 0x8 (0x0f0e003f) + offset 0x00000089",
+    assertEquals("0xF0E003F + offset 0x00000089",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
@@ -19,7 +19,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 13040013.
    * <p>
-   * Effective address is a general purpose register value.
+   * Operand is a general purpose register value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -41,7 +41,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 03030003.
    * <p>
-   * Effective address is a general purpose register value.
+   * Operand is a general purpose register value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -63,7 +63,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 13060022.
    * <p>
-   * Effective address is a seq stored value.
+   * Operand is a seq stored value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -85,7 +85,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 21060026.
    * <p>
-   * Effective address is a seq stored value.
+   * Operand is a seq stored value.
    * <p>
    * This is called for getting this seq's chr_p +4 bytes appears to be the opponent chr_p
    * TODO: Is that true?
@@ -110,7 +110,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 06060032.
    * <p>
-   * Effective address is a global value.
+   * Operand is a global value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -133,7 +133,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 06060039.
    * <p>
-   * Effective address is a global value.
+   * Operand is a global value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -156,7 +156,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 0206003e.
    * <p>
-   * Effective address is an immediate value plus offset.
+   * Operand is an immediate value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -179,7 +179,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 0206003f.
    * <p>
-   * Effective address is an immediate value plus offset.
+   * Operand is an immediate value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -201,7 +201,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 03030080.
    * <p>
-   * Effective address is a general purpose register value plus general purpose register value
+   * Operand is a general purpose register value plus general purpose register value
    *
    * @throws Exception If any Exception occurs
    */
@@ -223,7 +223,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 210600af.
    * <p>
-   * Effective address is a seq stored value plus general purpose register value.
+   * Operand is a seq stored value plus general purpose register value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -245,7 +245,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 060600b4.
    * <p>
-   * Effective address is a global value plus seq stored value.
+   * Operand is a global value plus seq stored value.
    *
    * @throws Exception If any Exception occurs
    */
@@ -268,7 +268,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 020600be.
    * <p>
-   * Effective address is a read immediate value plus seq stored value plus offset.
+   * Operand is a read immediate value plus seq stored value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -293,7 +293,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 020600bf.
    * <p>
-   * Effective address is a peek immediate value plus general purpose register value plus offset.
+   * Operand is a peek immediate value plus general purpose register value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -318,7 +318,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 03030042.
    * <p>
-   * Effective address is a general purpose register value plus offset.
+   * Operand is a general purpose register value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -340,7 +340,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 03030053.
    * <p>
-   * Effective address is a general purpose register value plus offset.
+   * Operand is a general purpose register value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -362,7 +362,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 01500068.
    * <p>
-   * Effective address is a seq stored value plus offset.
+   * Operand is a seq stored value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -384,7 +384,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 03030066.
    * <p>
-   * Effective address is a seq stored value plus offset.
+   * Operand is a seq stored value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -406,7 +406,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 01500070.
    * <p>
-   * Effective address is a global value plus offset.
+   * Operand is a global value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -429,7 +429,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 3e020079.
    * <p>
-   * Effective address is a global value plus offset.
+   * Operand is a global value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -452,7 +452,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 0f0d007e.
    * <p>
-   * Effective address is a read immediate value plus offset.
+   * Operand is a read immediate value plus offset.
    *
    * @throws Exception If any Exception occurs
    */
@@ -476,7 +476,7 @@ public class SEQRegCMD1Test {
   /**
    * Tests calling opcode 0f0d007f.
    * <p>
-   * Effective address is a peeked immediate value plus offset.
+   * Operand is a peeked immediate value plus offset.
    *
    * @throws Exception If any Exception occurs
    */

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
@@ -329,7 +329,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr2 + offset 0x00000000", ea.getDescription());
+    assertEquals("*gpr2 + offset 0x0", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -351,7 +351,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr19 + offset 0x00000004", ea.getDescription());
+    assertEquals("*gpr19 + offset 0x4", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -373,7 +373,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0xa0 + offset 0x0000005C", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0xa0 + offset 0x5C", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -395,7 +395,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000020", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x20", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -417,7 +417,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("HITBOX_IDENTITY_MATRIX + offset 0x00000060", ea.getDescription());
+    assertEquals("HITBOX_IDENTITY_MATRIX + offset 0x60", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -440,7 +440,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("SAVE_DATA + offset 0x000001B6", ea.getDescription());
+    assertEquals("SAVE_DATA + offset 0x1B6", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -464,7 +464,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7e, 0x00, 0x00, 0x10, 0x00}, ea.getBytes());
-    assertEquals("0x0 + offset 0x00001000",
+    assertEquals("0x0 + offset 0x1000",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);
@@ -489,7 +489,7 @@ public class SEQRegCMD1Test {
     assertEquals(0x8, bs.offset());
     assertArrayEquals(new byte[]{0x0f, 0x0d, 0x00, 0x7f, 0x00, 0x00, 0x00, (byte) 0x89},
         ea.getBytes());
-    assertEquals("0xF0E003F + offset 0x00000089",
+    assertEquals("0xF0E003F + offset 0x89",
         ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof ImmediateOperand);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -93,7 +93,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr21; PAUSE_GAME + offset 0x00000000", ea.getDescription());
+    assertEquals("gpr21; PAUSE_GAME + offset 0x0", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -277,7 +277,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr4 + offset 0x00000024; 0x20004", ea.getDescription());
+    assertEquals("*gpr4 + offset 0x24; 0x20004", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -308,7 +308,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr19 + offset 0x00000068; GAME_INFO + offset 0x0000221C", ea.getDescription());
+    assertEquals("*gpr19 + offset 0x68; GAME_INFO + offset 0x221C", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -340,7 +340,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000018; 0x1734", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x18; 0x1734", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -371,7 +371,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x0000005C; 0x3F000000", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x5C; 0x3F000000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -402,7 +402,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("GAME_INFO + offset 0x00000000; 0x200", ea.getDescription());
+    assertEquals("GAME_INFO + offset 0x0; 0x200", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -33,7 +33,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr2; gpr19", ea.getDescription());
+    assertEquals("gpr2, gpr19", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -63,7 +63,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr19; seq_p_sp->field_0x17", ea.getDescription());
+    assertEquals("gpr19, seq_p_sp->field_0x17", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -93,7 +93,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr21; PAUSE_GAME + offset 0x0", ea.getDescription());
+    assertEquals("gpr21, PAUSE_GAME + offset 0x0", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -124,7 +124,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0e; gpr2", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0e, gpr2", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -154,7 +154,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0e; seq_p_sp->field_0x08", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0e, seq_p_sp->field_0x08", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -184,7 +184,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x02; 0x1", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x02, 0x1", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -214,7 +214,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x05; 0x1BF24", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x05, 0x1BF24", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -246,7 +246,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("0xC; 0x0", ea.getDescription());
+    assertEquals("0xC, 0x0", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -277,7 +277,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr4 + offset 0x24; 0x20004", ea.getDescription());
+    assertEquals("*gpr4 + offset 0x24, 0x20004", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -308,7 +308,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr19 + offset 0x68; GAME_INFO + offset 0x221C", ea.getDescription());
+    assertEquals("*gpr19 + offset 0x68, GAME_INFO + offset 0x221C", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -340,7 +340,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x18; 0x1734", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x18, 0x1734", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -371,7 +371,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x5C; 0x3F000000", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x5C, 0x3F000000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -402,7 +402,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("GAME_INFO + offset 0x0; 0x200", ea.getDescription());
+    assertEquals("GAME_INFO + offset 0x0, 0x200", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -434,7 +434,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr2; *gpr19 + *gpr2 + 0000", ea.getDescription());
+    assertEquals("gpr2, *gpr19 + *gpr2 + 0000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -184,7 +184,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x02; Immediate value offset 0x4 (0x00000001)", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x02; 0x1", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -214,7 +214,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x05; Immediate value offset 0x4 (0x0001bf24)", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x05; 0x1BF24", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -246,7 +246,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("Immediate value offset 0x4 (0x0000000c); Immediate value offset 0xc (0x00000000)", ea.getDescription());
+    assertEquals("0xC; 0x0", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -277,7 +277,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*gpr4 + offset 0x00000024; Immediate value offset 0xc (0x00020004)", ea.getDescription());
+    assertEquals("*gpr4 + offset 0x00000024; 0x20004", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -340,7 +340,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000018; Immediate value offset 0xc (0x00001734)", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000018; 0x1734", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -371,7 +371,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x0000005C; Immediate value offset 0xc (0x3f000000)", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x0000005C; 0x3F000000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -402,7 +402,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("GAME_INFO + offset 0x00000000; Immediate value offset 0xc (0x00000200)", ea.getDescription());
+    assertEquals("GAME_INFO + offset 0x00000000; 0x200", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -33,7 +33,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr2; EA: gpr19", ea.getDescription());
+    assertEquals("gpr2; gpr19", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -63,7 +63,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr19; EA: seq_p_sp->field_0x17", ea.getDescription());
+    assertEquals("gpr19; seq_p_sp->field_0x17", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -93,7 +93,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr21; EA: PAUSE_GAME + offset 0x00000000", ea.getDescription());
+    assertEquals("gpr21; PAUSE_GAME + offset 0x00000000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -124,7 +124,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x0e; EA: gpr2", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0e; gpr2", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -154,7 +154,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x0e; EA: seq_p_sp->field_0x08", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x0e; seq_p_sp->field_0x08", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -184,7 +184,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x02; EA: Immediate value offset 0x4 (0x00000001)", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x02; Immediate value offset 0x4 (0x00000001)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -214,7 +214,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: seq_p_sp->field_0x05; EA: Immediate value offset 0x4 (0x0001bf24)", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x05; Immediate value offset 0x4 (0x0001bf24)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -246,7 +246,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: Immediate value offset 0x4 (0x0000000c); EA: Immediate value offset 0xc (0x00000000)", ea.getDescription());
+    assertEquals("Immediate value offset 0x4 (0x0000000c); Immediate value offset 0xc (0x00000000)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof ImmediateOperand);
     ImmediateOperand immediateOperand = (ImmediateOperand) operand;
@@ -277,7 +277,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *gpr4 + offset 0x00000024; EA: Immediate value offset 0xc (0x00020004)", ea.getDescription());
+    assertEquals("*gpr4 + offset 0x00000024; Immediate value offset 0xc (0x00020004)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -308,7 +308,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *gpr19 + offset 0x00000068; EA: GAME_INFO + offset 0x0000221C", ea.getDescription());
+    assertEquals("*gpr19 + offset 0x00000068; GAME_INFO + offset 0x0000221C", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -340,7 +340,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *seq_p_sp->field_0x98 + offset 0x00000018; EA: Immediate value offset 0xc (0x00001734)", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x00000018; Immediate value offset 0xc (0x00001734)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -371,7 +371,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: *seq_p_sp->field_0x98 + offset 0x0000005C; EA: Immediate value offset 0xc (0x3f000000)", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x98 + offset 0x0000005C; Immediate value offset 0xc (0x3f000000)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -402,7 +402,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: GAME_INFO + offset 0x00000000; EA: Immediate value offset 0xc (0x00000200)", ea.getDescription());
+    assertEquals("GAME_INFO + offset 0x00000000; Immediate value offset 0xc (0x00000200)", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GlobalOperand);
     GlobalOperand globalOperand = (GlobalOperand) operand;
@@ -434,7 +434,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("EA: gpr2; EA: *gpr19 + *gpr2 + 0000", ea.getDescription());
+    assertEquals("gpr2; *gpr19 + *gpr2 + 0000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -20,8 +20,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04020213.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register pointer.</li>
-   *   <li>Second effective address is a general purpose register pointer.</li>
+   *   <li>First operand is a general purpose register pointer.</li>
+   *   <li>Second operand is a general purpose register pointer.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -50,8 +50,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 0402132f.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register pointer.</li>
-   *   <li>Second effective address is a seq stored pointer.</li>
+   *   <li>First operand is a general purpose register pointer.</li>
+   *   <li>Second operand is a seq stored pointer.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -80,8 +80,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 0616157b.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register pointer.</li>
-   *   <li>Second effective address is a global pointer plus offset.</li>
+   *   <li>First operand is a general purpose register pointer.</li>
+   *   <li>Second operand is a global pointer plus offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -111,8 +111,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04022602.
    *
    * <ul>
-   *   <li>First effective address is a seq stored pointer.</li>
-   *   <li>Second effective address is a general purpose register pointer.</li>
+   *   <li>First operand is a seq stored pointer.</li>
+   *   <li>Second operand is a general purpose register pointer.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -141,8 +141,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 22052620.
    *
    * <ul>
-   *   <li>First effective address is a seq stored pointer.</li>
-   *   <li>Second effective address is a seq stored pointer.</li>
+   *   <li>First operand is a seq stored pointer.</li>
+   *   <li>Second operand is a seq stored pointer.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -171,8 +171,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04021a3f.
    *
    * <ul>
-   *   <li>First effective address is a seq stored pointer.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a seq stored pointer.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -201,8 +201,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 09081d3f.
    *
    * <ul>
-   *   <li>First effective address is a seq stored pointer.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a seq stored pointer.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -232,8 +232,8 @@ public class SEQRegCMD2Test {
    *
    *
    * <ul>
-   *   <li>First effective address is an immediate value offset.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is an immediate value offset.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -263,8 +263,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04034400.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register value plus offset.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a general purpose register value plus offset.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -294,8 +294,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 09015300.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register value plus offset.</li>
-   *   <li>Second effective address is a global value plus offset.</li>
+   *   <li>First operand is a general purpose register value plus offset.</li>
+   *   <li>Second operand is a global value plus offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -326,8 +326,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04116600.
    *
    * <ul>
-   *   <li>First effective address is a seq stored value plus offset.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a seq stored value plus offset.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -357,8 +357,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04026600.
    *
    * <ul>
-   *   <li>First effective address is a seq stored value plus offset.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a seq stored value plus offset.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -388,8 +388,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 04037c00.
    *
    * <ul>
-   *   <li>First effective address is a global value plus offset.</li>
-   *   <li>Second effective address is an immediate value offset.</li>
+   *   <li>First operand is a global value plus offset.</li>
+   *   <li>Second operand is an immediate value offset.</li>
    * </ul>
    *
    * @throws Exception If any Exception occurs
@@ -420,8 +420,8 @@ public class SEQRegCMD2Test {
    * Tests calling opcode 09010293.
    *
    * <ul>
-   *   <li>First effective address is a general purpose register address.</li>
-   *   <li>Second effective address is a general purpose register value summed with a general
+   *   <li>First operand is a general purpose register address.</li>
+   *   <li>Second operand is a general purpose register value summed with a general
    *   purpose register value plus offset.</li>
    * </ul>
    *

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 public class SeqKingTest {
 
   // For unit testing: compare mode is off, verbose is off, and output files are deleted
-  private static final boolean COMPARE_MODE = true;
+  private static final boolean COMPARE_MODE = false;
   private static final boolean VERBOSE = false;
-  private static final boolean DELETE_FILE = false;
+  private static final boolean DELETE_FILE = true;
 
   @Test
   public void parseTitle() throws Exception {

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 public class SeqKingTest {
 
   // For unit testing: compare mode is off, verbose is off, and output files are deleted
-  private static final boolean COMPARE_MODE = false;
+  private static final boolean COMPARE_MODE = true;
   private static final boolean VERBOSE = false;
-  private static final boolean DELETE_FILE = true;
+  private static final boolean DELETE_FILE = false;
 
   @Test
   public void parseTitle() throws Exception {


### PR DESCRIPTION
This PR aims to improve the readability of the SEQ disassembler report. It includes a number of changes:

## General Changes

- Make byte sequences grey
- Add toggle button to make byte sequences invisible
- Remove wordiness of operand descriptions
- Separate operands with `,` instead of `;` to match what other disassemblers do
- Change order of opcode and operand to match what other disassemblers do
- Attempt to find where functions start and end in a smarter way than before
- Display correct field offset for seq operands
- Cleanup SEQ report code, and use real names of functions in places where appropriate (e.g. `SEQ_RegCMD1` instead of `get_effective_address`.
- Remove unused logic from HTML report to improve performance.

## Opcode Changes

- Add `branch_table` and `branch_table_link` opcodes for handling branch tables.
- Add opcodes relating to SEQ task execution (e.g. `SEQ_ReqSetPrev` and `TskExecFunc`)
- Add `chr_update` and `chr_update_2`
- Change the `soft_reset` opcode to `end`.
- Add the `set_timer_decrement` opcode.

## Before

![image](https://user-images.githubusercontent.com/4983605/161665813-daeb27ff-ce06-4a37-87b1-7cb3227a1a6e.png)

## After

![image](https://user-images.githubusercontent.com/4983605/161665822-99caa420-2014-495e-95bc-888256834a47.png)

## After (with byte display toggle on)

![image](https://user-images.githubusercontent.com/4983605/161665852-b45cce40-6aca-4f4c-b08d-e1b1a7883d47.png)
