### PR TITLE
Fix Unit Tests for Windows and Linux

### DIFF
--- a/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
+++ b/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
@@ -448,7 +448,7 @@ public class MusyXExtract {
     }
     String match = matcher.group(1);
     int result = Integer.parseInt(match, 16);
-    System.out.printf("ID is %d (0x%X) for file %s\n", result, result, dspPath);
+    System.out.printf("  ID is %d (0x%X) for file %s\n", result, result, dspPath);
     return result;
   }
 

--- a/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
+++ b/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
@@ -448,9 +448,7 @@ public class MusyXExtract {
       throw new IOException("Invalid .dsp filename: " + fileName);
     }
     String match = matcher.group(1);
-    int result = Integer.parseInt(match, 16);
-    System.out.printf("  ID is %d (0x%X) for file %s\n", result, result, dspPath);
-    return result;
+    return Integer.parseInt(match, 16);
   }
 
   /**

--- a/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
+++ b/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
@@ -447,7 +447,9 @@ public class MusyXExtract {
       throw new IOException("Invalid .dsp filename: " + fileName);
     }
     String match = matcher.group(1);
-    return Integer.parseInt(match, 16);
+    int result = Integer.parseInt(match, 16);
+    System.out.printf("ID is %d (0x%X) for file %s\n", result, result, dspPath);
+    return result;
   }
 
   /**

--- a/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
+++ b/src/main/java/com/github/nicholasmoser/audio/MusyXExtract.java
@@ -416,6 +416,7 @@ public class MusyXExtract {
       List<Path> dspPaths = Files.list(inputPath)
           .filter(Files::isRegularFile)
           .filter(path -> path.toString().endsWith(".dsp"))
+          .sorted()
           .collect(Collectors.toList());
       for (Path dspPath : dspPaths) {
         int id = getId(dspPath);

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -103,8 +104,14 @@ public class MustXExtractTest {
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertEquals(Files.list(outputDir).count(), Files.list(outputDir2).count());
       } else {
-        System.out.println("inputSdi size = " + Files.size(inputSdi));
-        System.out.println("outputSdi size = " + Files.size(outputSdi));
+        int mismatch = (int) Files.mismatch(inputSdi, outputSdi);
+        System.out.println("mismatch at offset " + mismatch);
+        byte[] inputSdiBytes = Files.readAllBytes(inputSdi);
+        System.out.println(inputSdi);
+        System.out.println(Arrays.toString(Arrays.copyOfRange(inputSdiBytes, mismatch, mismatch + 0x10)));
+        byte[] outputSdiBytes = Files.readAllBytes(outputSdi);
+        System.out.println(outputSdi);
+        System.out.println(Arrays.toString(Arrays.copyOfRange(outputSdiBytes, mismatch, mismatch + 0x10)));
         assertFalse(Files.mismatch(inputSdi, outputSdi) != -1);
         long delta = (long) (Files.size(inputSam) * 0.03);
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -79,6 +79,7 @@ public class MustXExtractTest {
   @MethodSource("samSdiPathProvider")
   public void testExtractAndRepack(Path inputSdi, Path inputSam) throws Exception {
     // Outputs
+    System.out.println(inputSdi);
     Path tempDir = FileUtils.getTempDirectory();
     Path outputDir = tempDir.resolve(UUID.randomUUID().toString());
     Path outputDir2 = tempDir.resolve(UUID.randomUUID().toString());

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -2,10 +2,7 @@ package com.github.nicholasmoser.audio;
 
 import static com.github.nicholasmoser.utils.TestUtil.assertDirectoriesEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.github.nicholasmoser.testing.Prereqs;
@@ -17,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -79,7 +75,6 @@ public class MustXExtractTest {
   @MethodSource("samSdiPathProvider")
   public void testExtractAndRepack(Path inputSdi, Path inputSam) throws Exception {
     // Outputs
-    System.out.println(inputSdi);
     Path tempDir = FileUtils.getTempDirectory();
     Path outputDir = tempDir.resolve(UUID.randomUUID().toString());
     Path outputDir2 = tempDir.resolve(UUID.randomUUID().toString());
@@ -105,15 +100,7 @@ public class MustXExtractTest {
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertEquals(Files.list(outputDir).count(), Files.list(outputDir2).count());
       } else {
-        int mismatch = (int) Files.mismatch(inputSdi, outputSdi);
-        if (mismatch != -1) {
-          System.out.println("  mismatch = " + mismatch);
-          byte[] bytes = Arrays.copyOfRange(Files.readAllBytes(inputSdi), 0, 0x18);
-          System.out.println("  inputSdi = " + Arrays.toString(bytes));
-          bytes = Arrays.copyOfRange(Files.readAllBytes(outputSdi), 0, 0x18);
-          System.out.println("  outputSdi = " + Arrays.toString(bytes));
-        }
-        assertEquals(mismatch, -1);
+        assertEquals(Files.mismatch(inputSdi, outputSdi), -1);
         long delta = (long) (Files.size(inputSam) * 0.03);
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertDirectoriesEqual(outputDir, outputDir2);

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -103,6 +103,8 @@ public class MustXExtractTest {
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertEquals(Files.list(outputDir).count(), Files.list(outputDir2).count());
       } else {
+        System.out.println("inputSdi size = " + Files.size(inputSdi));
+        System.out.println("outputSdi size = " + Files.size(outputSdi));
         assertFalse(Files.mismatch(inputSdi, outputSdi) != -1);
         long delta = (long) (Files.size(inputSam) * 0.03);
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -105,7 +105,15 @@ public class MustXExtractTest {
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertEquals(Files.list(outputDir).count(), Files.list(outputDir2).count());
       } else {
-        assertFalse(Files.mismatch(inputSdi, outputSdi) != -1);
+        int mismatch = (int) Files.mismatch(inputSdi, outputSdi);
+        if (mismatch != -1) {
+          System.out.println("  mismatch = " + mismatch);
+          byte[] bytes = Arrays.copyOfRange(Files.readAllBytes(inputSdi), 0, 0x18);
+          System.out.println("  inputSdi = " + Arrays.toString(bytes));
+          bytes = Arrays.copyOfRange(Files.readAllBytes(outputSdi), 0, 0x18);
+          System.out.println("  outputSdi = " + Arrays.toString(bytes));
+        }
+        assertEquals(mismatch, -1);
         long delta = (long) (Files.size(inputSam) * 0.03);
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertDirectoriesEqual(outputDir, outputDir2);

--- a/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
+++ b/src/test/java/com/github/nicholasmoser/audio/MustXExtractTest.java
@@ -104,14 +104,6 @@ public class MustXExtractTest {
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);
         assertEquals(Files.list(outputDir).count(), Files.list(outputDir2).count());
       } else {
-        int mismatch = (int) Files.mismatch(inputSdi, outputSdi);
-        System.out.println("mismatch at offset " + mismatch);
-        byte[] inputSdiBytes = Files.readAllBytes(inputSdi);
-        System.out.println(inputSdi);
-        System.out.println(Arrays.toString(Arrays.copyOfRange(inputSdiBytes, mismatch, mismatch + 0x10)));
-        byte[] outputSdiBytes = Files.readAllBytes(outputSdi);
-        System.out.println(outputSdi);
-        System.out.println(Arrays.toString(Arrays.copyOfRange(outputSdiBytes, mismatch, mismatch + 0x10)));
         assertFalse(Files.mismatch(inputSdi, outputSdi) != -1);
         long delta = (long) (Files.size(inputSam) * 0.03);
         assertEquals(Files.size(inputSam), Files.size(outputSam), delta);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD1Test.java
@@ -74,7 +74,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0a", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x28", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -99,7 +99,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0e", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x38", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -234,7 +234,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0xbc + *gpr23 + 0000", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x2f0 + *gpr23 + 0000", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -373,7 +373,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0xa0 + offset 0x5C", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x280 + offset 0x5C", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -395,7 +395,7 @@ public class SEQRegCMD1Test {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     assertEquals(bytes.length, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x20", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x260 + offset 0x20", ea.getDescription());
     Operand operand = ea.getOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SEQRegCMD2Test.java
@@ -63,7 +63,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("gpr19, seq_p_sp->field_0x17", ea.getDescription());
+    assertEquals("gpr19, seq_p_sp->field_0x5c", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof GPROperand);
     GPROperand gprOperand = (GPROperand) operand;
@@ -124,7 +124,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0e, gpr2", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x38, gpr2", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -154,7 +154,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x4, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x0e, seq_p_sp->field_0x08", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x38, seq_p_sp->field_0x20", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -184,7 +184,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x02, 0x1", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x08, 0x1", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -214,7 +214,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x8, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("seq_p_sp->field_0x05, 0x1BF24", ea.getDescription());
+    assertEquals("seq_p_sp->field_0x14, 0x1BF24", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -340,7 +340,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x18, 0x1734", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x260 + offset 0x18, 0x1734", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;
@@ -371,7 +371,7 @@ public class SEQRegCMD2Test {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     assertEquals(0x10, bs.offset());
     assertArrayEquals(bytes, ea.getBytes());
-    assertEquals("*seq_p_sp->field_0x98 + offset 0x5C, 0x3F000000", ea.getDescription());
+    assertEquals("*seq_p_sp->field_0x260 + offset 0x5C, 0x3F000000", ea.getDescription());
     Operand operand = ea.getFirstOperand();
     assertTrue(operand instanceof SeqOperand);
     SeqOperand seqOperand = (SeqOperand) operand;

--- a/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
+++ b/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
+import com.sun.jna.Platform;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -173,8 +174,7 @@ public class ISOCompareToolTest {
     Files.createFile(temp2.resolve("test"));
     try {
       String difference = ISOCompareTool.getDifference(temp1, temp2, ISO1, ISO2);
-      // Currently Windows-only
-      String expectedMessage = "\nFiles only in ISO1\n"
+      String windowsMessage = "\nFiles only in ISO1\n"
           + "------------------\n"
           + "test\\test\n"
           + "\n"
@@ -184,7 +184,21 @@ public class ISOCompareToolTest {
           + "\n"
           + "Changed Files\n"
           + "-------------\n";
-      assertEquals(expectedMessage, difference);
+      String message = "\nFiles only in ISO1\n"
+          + "------------------\n"
+          + "test/test\n"
+          + "\n"
+          + "Files only in ISO2\n"
+          + "------------------\n"
+          + "test\n"
+          + "\n"
+          + "Changed Files\n"
+          + "-------------\n";
+      if (Platform.isWindows()) {
+        assertEquals(windowsMessage, difference);
+      } else {
+        assertEquals(message, difference);
+      }
     } finally {
       MoreFiles.deleteRecursively(temp1, RecursiveDeleteOption.ALLOW_INSECURE);
       MoreFiles.deleteRecursively(temp2, RecursiveDeleteOption.ALLOW_INSECURE);
@@ -205,8 +219,7 @@ public class ISOCompareToolTest {
     Files.createFile(temp1.resolve("test/test"));
     try {
       String difference = ISOCompareTool.getDifference(temp1, temp2, ISO1, ISO2);
-      // Currently Windows-only
-      String expectedMessage = "\nFiles only in ISO1\n"
+      String windowsMessage = "\nFiles only in ISO1\n"
           + "------------------\n"
           + "test\\test\n"
           + "\n"
@@ -215,7 +228,20 @@ public class ISOCompareToolTest {
           + "\n"
           + "Changed Files\n"
           + "-------------\n";
-      assertEquals(expectedMessage, difference);
+      String message = "\nFiles only in ISO1\n"
+          + "------------------\n"
+          + "test/test\n"
+          + "\n"
+          + "Files only in ISO2\n"
+          + "------------------\n"
+          + "\n"
+          + "Changed Files\n"
+          + "-------------\n";
+      if (Platform.isWindows()) {
+        assertEquals(windowsMessage, difference);
+      } else {
+        assertEquals(message, difference);
+      }
     } finally {
       MoreFiles.deleteRecursively(temp1, RecursiveDeleteOption.ALLOW_INSECURE);
       MoreFiles.deleteRecursively(temp2, RecursiveDeleteOption.ALLOW_INSECURE);


### PR DESCRIPTION
Fix unit tests for Windows and Linux. Windows tests broke from https://github.com/NicholasMoser/GNTool/pull/91 and Linux tests never passed in the first place. By getting Linux tests to pass, [Linux binaries can be released](https://github.com/NicholasMoser/GNTool/issues/89).

- https://github.com/NicholasMoser/GNTool/pull/91 broke the tests in `SEQRegCMD1Test.java` and `SEQRegCMD2Test.java` due to the field offset for `seq_p_sp` changing. This has now been fixed.
- Linux fails `ISOCompareToolTest.java` as it uses `/` as the path separator instead of `\`. This has now been fixed.
- Linux fails `MustXExtractTest.java` as files must be listed in alphabetic order but are instead listed in "random" order. This has now been fixed by always sorting the list of files.