### PR TITLE
Fix for instantiation of SeqOperand

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD1.java
@@ -106,7 +106,7 @@ public class SEQ_RegCMD1 {
         if (lastSixBits < 0x18) {
           operand = new GPROperand(lastSixBits, false);
         } else if (lastSixBits < 0x30) {
-          operand = new SeqOperand(lastSixBits * 4, false);
+          operand = new SeqOperand(lastSixBits - 0x18, false);
         } else {
           operand = SEQ_RegGP(lastSixBits, false);
         }
@@ -128,7 +128,7 @@ public class SEQ_RegCMD1 {
       if (lastSixBits < 0x18) {
         operand = new GPROperand(lastSixBits, false);
       } else if (lastSixBits < 0x30) {
-        operand = new SeqOperand(lastSixBits * 4, false);
+        operand = new SeqOperand(lastSixBits - 0x18, false);
       } else {
         operand = SEQ_RegGP(lastSixBits, false);
       }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SEQ_RegCMD2.java
@@ -82,7 +82,7 @@ public class SEQ_RegCMD2 {
       if (lastSixBits < 0x18) {
         firstOperand = new GPROperand(lastSixBits, false);
       } else if (lastSixBits < 0x30) {
-        firstOperand = new SeqOperand(lastSixBits * 4, false);
+        firstOperand = new SeqOperand(lastSixBits - 0x18, false);
       } else {
         firstOperand = SEQ_RegGP(lastSixBits, false);
       }
@@ -117,7 +117,7 @@ public class SEQ_RegCMD2 {
         if (lastSixBits2 < 0x18) {
           secondOperand = new GPROperand(lastSixBits2, false);
         } else if (lastSixBits2 < 0x30) {
-          secondOperand = new SeqOperand(lastSixBits2 * 4, false);
+          secondOperand = new SeqOperand(lastSixBits2 - 0x18, false);
         } else {
           secondOperand = SEQ_RegGP(lastSixBits2, false);
         }
@@ -141,7 +141,7 @@ public class SEQ_RegCMD2 {
       if (lastSixBits2 < 0x18) {
         secondOperand = new GPROperand(lastSixBits2, false);
       } else if (lastSixBits2 < 0x30) {
-        secondOperand = new SeqOperand(lastSixBits2 * 4, false);
+        secondOperand = new SeqOperand(lastSixBits2 - 0x18, false);
       } else {
         secondOperand = SEQ_RegGP(lastSixBits2, false);
       }


### PR DESCRIPTION
Noticed that instantiations of SeqOperands from different parts of SEQ_RegCMD were treated differently in offsets. They are all treated the
same in the .dol, just that the order of the subtraction and
multiplication is inverted in some places so that it looks like either
(op - 0x18) * 4
or
op * 4 - 0x60
depending on exact position, but the end result is the same