### PR TITLE
FFmpeg non windows system fix

### DIFF
--- a/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
+++ b/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
@@ -17,11 +17,22 @@ public class FFmpeg {
    * @throws IOException If an I/O error occurs.
    */
   public static String prepareSoundEffect(Path input, Path output) throws IOException {
-    if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
-      throw new IOException("ffmpeg.exe cannot be found.");
+    String ffmpeg;
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      ffmpeg = "ffmpeg.exe";
+      if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
+        throw new IOException("ffmpeg.exe cannot be found.");
+      }
+    } else {
+      try {
+        ffmpeg = "ffmpeg";
+        Runtime.getRuntime().exec("ffmpeg");
+      } catch (Exception e) {
+        throw new IOException("ffmpeg cannot be found.");
+      }
     }
     try {
-      Process process = new ProcessBuilder("ffmpeg.exe", "-y", "-i", input.toString(), "-ar",
+      Process process = new ProcessBuilder(ffmpeg, "-y", "-i", input.toString(), "-ar",
           "32000", "-acodec", "pcm_s16le", "-map_channel", "0.0.0", "-loglevel", "quiet", output.toString()).start();
       process.waitFor();
       return new String(process.getErrorStream().readAllBytes());
@@ -41,11 +52,22 @@ public class FFmpeg {
    * @throws IOException If an I/O error occurs.
    */
   public static String prepareMusic(Path input, Path output) throws IOException {
-    if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
-      throw new IOException("ffmpeg.exe cannot be found.");
+    String ffmpeg;
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      ffmpeg = "ffmpeg.exe";
+      if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
+        throw new IOException("ffmpeg.exe cannot be found.");
+      }
+    } else {
+      try {
+        ffmpeg = "ffmpeg";
+        Runtime.getRuntime().exec("ffmpeg");
+      } catch (Exception e) {
+        throw new IOException("ffmpeg cannot be found.");
+      }
     }
     try {
-      Process process = new ProcessBuilder("ffmpeg.exe", "-y", "-i", input.toString(), "-ar",
+      Process process = new ProcessBuilder(ffmpeg, "-y", "-i", input.toString(), "-ar",
           "48000", "-ac", "2", "-acodec", "pcm_s16le", "-bitexact", "-loglevel", "quiet", output.toString()).start();
       process.waitFor();
       return new String(process.getErrorStream().readAllBytes());

--- a/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
+++ b/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
@@ -18,7 +18,7 @@ public class FFmpeg {
    */
   public static String prepareSoundEffect(Path input, Path output) throws IOException {
     String ffmpeg;
-    if (System.getProperty("os.name").startsWith("Windows")) {
+    if (Platform.isWindows()) {
       ffmpeg = "ffmpeg.exe";
       if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
         throw new IOException("ffmpeg.exe cannot be found.");
@@ -53,7 +53,7 @@ public class FFmpeg {
    */
   public static String prepareMusic(Path input, Path output) throws IOException {
     String ffmpeg;
-    if (System.getProperty("os.name").startsWith("Windows")) {
+    if (Platform.isWindows()) {
       ffmpeg = "ffmpeg.exe";
       if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
         throw new IOException("ffmpeg.exe cannot be found.");


### PR DESCRIPTION
Uses a variable to store ffmpeg executable name, if system is windows, use ffmpeg.exe, else use ffmpeg.
If not Windows, test if ffmpeg can be executed in runtime, and throw error if it can not be found.