### PR TITLE
Create isWindows method to use across GNTool

### DIFF
--- a/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
+++ b/src/main/java/com/github/nicholasmoser/audio/FFmpeg.java
@@ -1,5 +1,6 @@
 package com.github.nicholasmoser.audio;
 
+import com.github.nicholasmoser.utils.GUIUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,7 +19,7 @@ public class FFmpeg {
    */
   public static String prepareSoundEffect(Path input, Path output) throws IOException {
     String ffmpeg;
-    if (Platform.isWindows()) {
+    if (GUIUtils.isWindows()) {
       ffmpeg = "ffmpeg.exe";
       if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
         throw new IOException("ffmpeg.exe cannot be found.");
@@ -53,7 +54,7 @@ public class FFmpeg {
    */
   public static String prepareMusic(Path input, Path output) throws IOException {
     String ffmpeg;
-    if (Platform.isWindows()) {
+    if (GUIUtils.isWindows()) {
       ffmpeg = "ffmpeg.exe";
       if (!Files.isRegularFile(Paths.get("ffmpeg.exe"))) {
         throw new IOException("ffmpeg.exe cannot be found.");

--- a/src/main/java/com/github/nicholasmoser/utils/GUIUtils.java
+++ b/src/main/java/com/github/nicholasmoser/utils/GUIUtils.java
@@ -172,4 +172,11 @@ public class GUIUtils {
     }
     return Optional.empty();
   }
+
+  /**
+   * @return If the platform this is running on is Windows.
+   */
+  public static boolean isWindows() {
+    return System.getProperty("os.name").startsWith("Windows");
+  }
 }

--- a/src/test/java/com/github/nicholasmoser/fpk/PRSCompare.java
+++ b/src/test/java/com/github/nicholasmoser/fpk/PRSCompare.java
@@ -1,8 +1,8 @@
 package com.github.nicholasmoser.fpk;
 
 import com.github.nicholasmoser.fpk.NativePRS.PRS;
+import com.github.nicholasmoser.utils.GUIUtils;
 import com.google.common.math.IntMath;
-import com.sun.jna.Platform;
 import java.math.RoundingMode;
 import java.nio.ShortBuffer;
 import java.nio.file.Files;
@@ -15,7 +15,7 @@ public class PRSCompare {
   @Test
   @Disabled("This test is not ready to be used yet.")
   public void testCompare() throws Exception {
-    if (!Platform.isWindows()) {
+    if (!GUIUtils.isWindows()) {
       System.out.println("Platforms other than Windows not supported for this test.");
       return;
     }

--- a/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
+++ b/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.nicholasmoser.utils.GUIUtils;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
-import com.sun.jna.Platform;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
+++ b/src/test/java/com/github/nicholasmoser/tools/ISOCompareToolTest.java
@@ -2,6 +2,7 @@ package com.github.nicholasmoser.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.nicholasmoser.utils.GUIUtils;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.sun.jna.Platform;
@@ -194,7 +195,7 @@ public class ISOCompareToolTest {
           + "\n"
           + "Changed Files\n"
           + "-------------\n";
-      if (Platform.isWindows()) {
+      if (GUIUtils.isWindows()) {
         assertEquals(windowsMessage, difference);
       } else {
         assertEquals(message, difference);
@@ -237,7 +238,7 @@ public class ISOCompareToolTest {
           + "\n"
           + "Changed Files\n"
           + "-------------\n";
-      if (Platform.isWindows()) {
+      if (GUIUtils.isWindows()) {
         assertEquals(windowsMessage, difference);
       } else {
         assertEquals(message, difference);


### PR DESCRIPTION
Before this PR, `Platform.isWindows()` was being used to check if Windows is the operating system. `Platform.isWindows()` is part of the dependency `jna` which I'd prefer to keep test scope since it currently has no reason to be bundled with GNTool. Therefore, since it's test scope `Platform.isWindows()` cannot be used in the main java code.

This PR adds a method to `GUIUtils` to check if Windows is the running platform in the same way that `jna` checks.