### PR TITLE
Additional Changes for Rev 3 Animation Support

### DIFF
--- a/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
+++ b/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
@@ -115,7 +115,7 @@ public class BoneAnimation {
    * Parse the bone animation from the file at the current offset. The offset of the parent
    * animation is also required to correctly read the data.
    *
-   * @param raf The file to read from.
+   * @param raf             The file to read from.
    * @param animationOffset The offset of the parent animation.
    * @return The bone animation.
    * @throws IOException If an I/O error occurs
@@ -167,6 +167,8 @@ public class BoneAnimation {
           float w = ByteUtils.readFloat(raf);
           coordinates.add(new Coordinate(x, y, z, w));
         }
+      } else {
+        throw new IOException(String.format("Unexpected flags: 0x%X", flags1));
       }
       junk2 = readJunkData(raf);
     }
@@ -226,12 +228,23 @@ public class BoneAnimation {
     //  int size = 16 - (baos.size() % 16);
     //  baos.write(new byte[size]);
     //}
-    for (Coordinate coordinate : coordinates) {
-      baos.write(ByteUtils.fromUint16(coordinate.getX()));
-      baos.write(ByteUtils.fromUint16(coordinate.getY()));
-      baos.write(ByteUtils.fromUint16(coordinate.getZ()));
-      baos.write(ByteUtils.fromUint16(coordinate.getW()));
+
+    if ((flags1 & 0x0002) != 0) {
+      for (Coordinate coordinate : coordinates) {
+        baos.write(ByteUtils.fromUint16(coordinate.getX()));
+        baos.write(ByteUtils.fromUint16(coordinate.getY()));
+        baos.write(ByteUtils.fromUint16(coordinate.getZ()));
+        baos.write(ByteUtils.fromUint16(coordinate.getW()));
+      }
+    } else if ((flags1 & 0x0004) != 0) {
+      for (Coordinate coordinate : coordinates) {
+        baos.write(ByteUtils.fromFloat(coordinate.getFloatX()));
+        baos.write(ByteUtils.fromFloat(coordinate.getFloatY()));
+        baos.write(ByteUtils.fromFloat(coordinate.getFloatZ()));
+        baos.write(ByteUtils.fromFloat(coordinate.getFloatW()));
+      }
     }
+
     if (junk2 != null) {
       baos.write(junk2.getBytes(JUNK_ENCODING));
     }

--- a/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
+++ b/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
@@ -228,6 +228,9 @@ public class BoneAnimation {
     //  int size = 16 - (baos.size() % 16);
     //  baos.write(new byte[size]);
     //}
+    if (baos.size() % 16 != 0) {
+      throw new IOException("Still need to implement this logic! See above TODO");
+    }
 
     if ((flags1 & 0x0002) != 0) {
       for (Coordinate coordinate : coordinates) {

--- a/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
+++ b/src/main/java/com/github/nicholasmoser/mot/BoneAnimation.java
@@ -219,17 +219,18 @@ public class BoneAnimation {
     for (Float value : timeValues) {
       baos.write(ByteUtils.fromFloat(value));
     }
-    if (junk1 != null) {
-      baos.write(junk1.getBytes(JUNK_ENCODING));
+
+    // Handle alignment
+    int bytesLeftToAlign = 16 - (baos.size() % 16);
+    if (bytesLeftToAlign == 16) {
+      bytesLeftToAlign = 0;
     }
-    // TODO: Use logic to actually pad when more animations are added
-    //if (baos.size() % 16 != 0) {
-    //  // Pad to 16-byte alignment
-    //  int size = 16 - (baos.size() % 16);
-    //  baos.write(new byte[size]);
-    //}
-    if (baos.size() % 16 != 0) {
-      throw new IOException("Still need to implement this logic! See above TODO");
+    if (junk1 != null && junk1.getBytes(JUNK_ENCODING).length == bytesLeftToAlign) {
+      // Pad with existing junk from original files
+      baos.write(junk1.getBytes(JUNK_ENCODING));
+    } else if (bytesLeftToAlign > 0) {
+      // Pad with zeroes
+      baos.write(new byte[bytesLeftToAlign]);
     }
 
     if ((flags1 & 0x0002) != 0) {
@@ -248,9 +249,19 @@ public class BoneAnimation {
       }
     }
 
-    if (junk2 != null) {
-      baos.write(junk2.getBytes(JUNK_ENCODING));
+    // Handle alignment
+    bytesLeftToAlign = 16 - (baos.size() % 16);
+    if (bytesLeftToAlign == 16) {
+      bytesLeftToAlign = 0;
     }
+    if (junk2 != null && junk2.getBytes(JUNK_ENCODING).length == bytesLeftToAlign) {
+      // Pad with existing junk from original files
+      baos.write(junk2.getBytes(JUNK_ENCODING));
+    } else if (bytesLeftToAlign > 0) {
+      // Pad with zeroes
+      baos.write(new byte[bytesLeftToAlign]);
+    }
+
     return baos.toByteArray();
   }
 

--- a/src/main/java/com/github/nicholasmoser/mot/Coordinate.java
+++ b/src/main/java/com/github/nicholasmoser/mot/Coordinate.java
@@ -4,8 +4,8 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
- * Represents a three-dimensional vertex with a fourth homogeneous vertex coordinate. See the
- * following links:
+ * Represents a three-dimensional vertex with a fourth homogeneous vertex coordinate. For more info
+ * on the fourth coordinate, see the following links:
  * <ul>
  *   <li><a href="https://en.wikipedia.org/wiki/Homogeneous_coordinates">Homogeneous Coordinates</a></li>
  *   <li><a href="https://www.reddit.com/r/computergraphics/comments/9fe1fq/why_xyzw_for_point_projection/">Why xyzw? (For point projection)</a></li>
@@ -14,90 +14,55 @@ import java.util.Objects;
  */
 public class Coordinate {
 
-  private short x;
-  private short y;
-  private short z;
-  private short w;
+  private final float x;
+  private final float y;
+  private final float z;
+  private final float w;
 
   public Coordinate(short x, short y, short z, short w) {
+    this.x = fromShort(x);
+    this.y = fromShort(y);
+    this.z = fromShort(z);
+    this.w = fromShort(w);
+  }
+
+  public Coordinate(float x, float y, float z, float w) {
     this.x = x;
     this.y = y;
     this.z = z;
     this.w = w;
   }
 
-  public Coordinate(float x, float y, float z, float w) {
-    this.x = fromFloat(x);
-    this.y = fromFloat(y);
-    this.z = fromFloat(z);
-    this.w = fromFloat(w);
-  }
-
   public short getX() {
-    return x;
+    return toShort(x);
   }
 
   public short getY() {
-    return y;
+    return toShort(y);
   }
 
   public short getZ() {
-    return z;
+    return toShort(z);
   }
 
   public short getW() {
-    return w;
+    return toShort(w);
   }
 
   public float getFloatX() {
-    return toFloat(x);
+    return x;
   }
 
   public float getFloatY() {
-    return toFloat(y);
+    return y;
   }
 
   public float getFloatZ() {
-    return toFloat(z);
+    return z;
   }
 
   public float getFloatW() {
-    return toFloat(w);
-  }
-
-  /**
-   * Sets the X coordinate. It will be truncated from 32 to 16 bits, resulting in precision loss.
-   * @param value The X coordinate.
-   */
-  public void setFloatX(float value) {
-    x = fromFloat(value);
-  }
-
-
-  /**
-   * Sets the Y coordinate. It will be truncated from 32 to 16 bits, resulting in precision loss.
-   * @param value The Y coordinate.
-   */
-  public void setFloatY(float value) {
-    y = fromFloat(value);
-  }
-
-
-  /**
-   * Sets the Z coordinate. It will be truncated from 32 to 16 bits, resulting in precision loss.
-   * @param value The Z coordinate.
-   */
-  public void setFloatZ(float value) {
-    z = fromFloat(value);
-  }
-
-
-  /**
-   * Sets the W coordinate. It will be truncated from 32 to 16 bits, resulting in precision loss.
-   * @param value The W coordinate.
-   */
-  public void setFloatW(float value) {
-    w = fromFloat(value);
+    return w;
   }
 
   /**
@@ -107,7 +72,7 @@ public class Coordinate {
    * @param value The short to convert to a float.
    * @return The float.
    */
-  private float toFloat(short value) {
+  private float fromShort(short value) {
     ByteBuffer buffer = ByteBuffer.allocate(4);
     buffer.putShort(value);
     buffer.putShort((short) 0);
@@ -124,7 +89,7 @@ public class Coordinate {
    * @param value
    * @return
    */
-  private short fromFloat(float value) {
+  private short toShort(float value) {
     ByteBuffer buffer = ByteBuffer.allocate(4);
     buffer.putFloat(value);
     buffer.flip();

--- a/src/main/java/com/github/nicholasmoser/mot/GNTAEditor.java
+++ b/src/main/java/com/github/nicholasmoser/mot/GNTAEditor.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.concurrent.Task;
+import javafx.event.ActionEvent;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Button;
@@ -172,6 +173,11 @@ public class GNTAEditor {
     } else {
       Message.info("Repack MOT First", "You must run Repack MOT first.");
     }
+  }
+
+  public void rewriteForGNT4(ActionEvent actionEvent) {
+    gnta.rewriteForGNT4();
+    updateAllControls(0, 0);
   }
 
   public void quit() {

--- a/src/main/java/com/github/nicholasmoser/mot/GNTAnimation.java
+++ b/src/main/java/com/github/nicholasmoser/mot/GNTAnimation.java
@@ -111,6 +111,18 @@ public class GNTAnimation {
 
     // Write out each bone animation header and data for them
     for (BoneAnimation boneAnimation : boneAnimations) {
+      header.write(boneAnimation.getHeaderBytes());
+      data.write(boneAnimation.getDataBytes());
+    }
+    return Bytes.concat(header.toByteArray(), data.toByteArray());
+  }
+
+  /**
+   * Rewrite a GNTAnimation to be compatible with GNT4. This involves changing 0x0204 animations
+   * (with floats) to 0x0202 animations (with shorts).
+   */
+  public void rewriteForGNT4() {
+    for (BoneAnimation boneAnimation : boneAnimations) {
       if (boneAnimation.getFlags1() == 0x0204) {
         int currentOffset = boneAnimation.getCoordinatesOffset();
         int lastSize = boneAnimation.getNumOfKeyFrames();
@@ -122,7 +134,7 @@ public class GNTAnimation {
             if ((lastSize*8) % 16 != 0){
               alignment = 16 - (lastSize*8) % 16;
             }
-            int timeValueOffset = currentOffset + (lastSize * 8);
+            // int timeValueOffset = currentOffset + (lastSize * 8);
             boneAnimation1.setTimeValuesOffset(currentOffset + (lastSize * 8) + alignment);
             if ((thisSize*4) % 16 != 0) {
               alignment = 16 - (thisSize*4) % 16;
@@ -136,10 +148,7 @@ public class GNTAnimation {
           }
         }
       }
-      header.write(boneAnimation.getHeaderBytes());
-      data.write(boneAnimation.getDataBytes());
     }
-    return Bytes.concat(header.toByteArray(), data.toByteArray());
   }
 
   /**

--- a/src/main/resources/com/github/nicholasmoser/mot/motedit.fxml
+++ b/src/main/resources/com/github/nicholasmoser/mot/motedit.fxml
@@ -71,6 +71,7 @@
                         <KeyCodeCombination alt="UP" code="T" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
                      </accelerator>
                   </MenuItem>
+                  <MenuItem mnemonicParsing="false" onAction="#rewriteForGNT4" text="Rewrite for GNT4" />
             <SeparatorMenuItem mnemonicParsing="false" />
             <MenuItem mnemonicParsing="false" onAction="#quit" text="Quit" />
           </items>

--- a/src/test/java/com/github/nicholasmoser/mot/CoordinateTest.java
+++ b/src/test/java/com/github/nicholasmoser/mot/CoordinateTest.java
@@ -13,12 +13,10 @@ public class CoordinateTest {
     short short2 = (short) 0x4048; // 3.125
     short short3 = (short) 0x3C93; // 0.017944336
     short short4 = (short) 0x404E; // 3.21875
-    short short5 = (short) 0x0000; // 0.0
     float float1 = (float) -0.0; // 0x8000
     float float2 = (float) 3.125; // 0x4048
     float float3 = (float) 0.017944336; // 0x3C93
     float float4 = (float) 3.21875; // 0x404E
-    float float5 = (float) 0.0; // 0x0000
 
     // Assert that float values can be returned
     Coordinate coordinate = new Coordinate(short1, short2, short3, short4);
@@ -31,34 +29,20 @@ public class CoordinateTest {
     Coordinate duplicateCoordinate = new Coordinate(short1, short2, short3, short4);
     assertEquals(coordinate, duplicateCoordinate);
 
-    // Assert that values can be changed and result in different coordinates
-    coordinate.setFloatX(float5);
-    assertNotEquals(coordinate, duplicateCoordinate);
-    assertEquals(short5, coordinate.getX());
-    assertEquals(float5, coordinate.getFloatX());
-    coordinate.setFloatY(float4);
-    assertEquals(short4, coordinate.getY());
-    assertEquals(float4, coordinate.getFloatY());
-
-    // Validate that truncating floats to a short results in precision loss
-    float pi = (float) 3.1415927;
-    coordinate.setFloatW(pi); // truncated to ~3.140625
-    assertNotEquals(pi, coordinate.getFloatW(), 0.0001); // Too much precision is lost so fail
-    assertEquals(pi, coordinate.getFloatW(), 0.001);
-
     // Test the alternate constructor
     Coordinate otherCoordinate = new Coordinate(float1, float2, float3, float4);
     assertEquals(otherCoordinate, duplicateCoordinate);
 
-    // Validate that the alternate constructor also results in precision loss
+    // Validate that the float constructor results in no precision loss
+    float pi = (float) 3.1415927;
     Coordinate otherCoordinate2 = new Coordinate(pi, pi, pi, pi);
-    assertNotEquals(pi, otherCoordinate2.getFloatX(), 0.0001); // Too much precision is lost so fail
+    assertEquals(pi, otherCoordinate2.getFloatX(), 0.0001);
     assertEquals(pi, otherCoordinate2.getFloatX(), 0.001);
-    assertNotEquals(pi, otherCoordinate2.getFloatY(), 0.0001); // Too much precision is lost so fail
+    assertEquals(pi, otherCoordinate2.getFloatY(), 0.0001);
     assertEquals(pi, otherCoordinate2.getFloatY(), 0.001);
-    assertNotEquals(pi, otherCoordinate2.getFloatZ(), 0.0001); // Too much precision is lost so fail
+    assertEquals(pi, otherCoordinate2.getFloatZ(), 0.0001);
     assertEquals(pi, otherCoordinate2.getFloatZ(), 0.001);
-    assertNotEquals(pi, otherCoordinate2.getFloatW(), 0.0001); // Too much precision is lost so fail
+    assertEquals(pi, otherCoordinate2.getFloatW(), 0.0001);
     assertEquals(pi, otherCoordinate2.getFloatW(), 0.001);
   }
 }


### PR DESCRIPTION
This PR adds some additional changes to @Athkore's branch for Rev 3 animation support. Specifically this fixes a few things related to 0x0202 animations (which use shorts) vs 0x0204 animations (which use floats).

- Internally store coordinates as floats. This is necessary to preserve the precision for 0x0204 animations. Previously we used shorts, since GNT4 only uses 0x0202 animations.
- Correctly write floats to files when the animation type is 0x0204.
- Add a setting to the Motion Editor to change 0x0204 animations to 0x0202 animations so that GNT4 can use them.[1]
- Make converting 0x0204 animations to 0x0202 animations optional, and only enabled by the above Motion Editor setting.
- Correctly fix 16-byte alignment when 0x0204 animations are converted to 0x0202 animations.

[1]
![image](https://user-images.githubusercontent.com/4983605/170394936-79a3093a-1d0b-43ab-8b13-95326d4f7e31.png)
