### PR TITLE
Add Recording Functionality

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -495,6 +495,10 @@ public class MenuController {
   public void setRecordingFlag() {
     try {
       String flag = recordingFlag.getValue();
+      String otherFlag = recordingCounterFlag.getValue();
+      if (flag.equals(otherFlag)) {
+        throw new IOException("Cannot modify CPU flag due to duplicate value.");
+      }
       int index = CPUFlags.getRecordingCPUFlag(uncompressedDirectory);
       if (index != -1) {
         CPUFlags.setCPUFlag(uncompressedDirectory, index, CPUFlags.CPU_BRANCHES.get(index));
@@ -513,6 +517,10 @@ public class MenuController {
   public void setRecordingCounterFlag() {
     try {
       String flag = recordingCounterFlag.getValue();
+      String otherFlag = recordingFlag.getValue();
+      if (flag.equals(otherFlag)) {
+        throw new IOException("Cannot modify CPU flag due to duplicate value.");
+      }
       int index = CPUFlags.getRecordingCounterCPUFlag(uncompressedDirectory);
       if (index != -1) {
         CPUFlags.setCPUFlag(uncompressedDirectory, index, CPUFlags.CPU_BRANCHES.get(index));

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -21,6 +21,7 @@ import com.github.nicholasmoser.gecko.GeckoWriter;
 import com.github.nicholasmoser.gnt4.chr.KabutoScalingFix;
 import com.github.nicholasmoser.gnt4.chr.KisamePhantomSwordFix;
 import com.github.nicholasmoser.gnt4.chr.ZabuzaPhantomSwordFix;
+import com.github.nicholasmoser.gnt4.cpu.CPUFlags;
 import com.github.nicholasmoser.gnt4.dol.CodeCaves.CodeCave;
 import com.github.nicholasmoser.gnt4.dol.DolDefragger;
 import com.github.nicholasmoser.gnt4.dol.DolHijack;
@@ -116,6 +117,8 @@ public class MenuController {
   public Button validateCodes;
   public Button addCodes;
   public Button removeCode;
+  public ComboBox<String> recordingFlag;
+  public ComboBox<String> recordingCounterFlag;
 
   /**
    * Toggles the code for fixing the audio.
@@ -485,6 +488,42 @@ public class MenuController {
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, "Failed to Apply Zabuza Phantom Sword Fix", e);
       Message.error("Failed to Apply Zabuza Phantom Sword Fix", e.getMessage());
+    }
+  }
+
+  @FXML
+  public void setRecordingFlag() {
+    try {
+      String flag = recordingFlag.getValue();
+      int index = CPUFlags.getRecordingCPUFlag(uncompressedDirectory);
+      if (index != -1) {
+        CPUFlags.setCPUFlag(uncompressedDirectory, index, CPUFlags.CPU_BRANCHES.get(index));
+      }
+      if (!flag.equals("UNUSED")) {
+        CPUFlags.setCPUFlag(uncompressedDirectory, CPUFlags.actionToCPUFlag(flag),
+            CPUFlags.RECORDING_OFFSET);
+      }
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error Setting Recording Flag", e);
+      Message.error("Error Setting Recording Flag", e.getMessage());
+    }
+  }
+
+  @FXML
+  public void setRecordingCounterFlag() {
+    try {
+      String flag = recordingCounterFlag.getValue();
+      int index = CPUFlags.getRecordingCounterCPUFlag(uncompressedDirectory);
+      if (index != -1) {
+        CPUFlags.setCPUFlag(uncompressedDirectory, index, CPUFlags.CPU_BRANCHES.get(index));
+      }
+      if (!flag.equals("UNUSED")) {
+        CPUFlags.setCPUFlag(uncompressedDirectory, CPUFlags.actionToCPUFlag(flag),
+            CPUFlags.RECORDING_COUNTER_OFFSET);
+      }
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error Setting Recording Counter Flag", e);
+      Message.error("Error Setting Recording Counter Flag", e.getMessage());
     }
   }
 
@@ -1263,6 +1302,7 @@ public class MenuController {
     selectedSeq.getSelectionModel().selectFirst();
     mainMenuCharacter.getItems().setAll(GNT4Characters.MAIN_MENU_CHARS);
     mainMenuCharacter.getSelectionModel().select(GNT4Characters.SAKURA);
+    initRecordingComboboxes();
     asyncRefresh();
   }
 
@@ -1362,7 +1402,8 @@ public class MenuController {
 
         if (DolHijack.isUsingCodeCave(dol, CodeCave.RECORDING)) {
           if (DolHijack.isUsingCodeCave(dol, CodeCave.EXI2)) {
-            throw new IOException("You are overwriting both recording code and EXI2 code, please log an issue to get this fixed.");
+            throw new IOException(
+                "You are overwriting both recording code and EXI2 code, please log an issue to get this fixed.");
           }
           String msg = "Your Gecko codes are currently overwriting recording functionality. ";
           msg += "These codes need to be moved so that recording functionality can be used. Are you okay with this?";
@@ -1536,9 +1577,7 @@ public class MenuController {
         LOGGER.log(Level.SEVERE, "Error Opening File", e);
       }
     });
-    openFile.setOnAction(event -> {
-      new Thread(task).start();
-    });
+    openFile.setOnAction(event -> new Thread(task).start());
     MenuItem openDirectory = new MenuItem("Open Directory");
     Task<Void> task2 = new Task<>() {
       @Override
@@ -1552,9 +1591,7 @@ public class MenuController {
         LOGGER.log(Level.SEVERE, "Error Opening Directory", e);
       }
     });
-    openDirectory.setOnAction(event -> {
-      new Thread(task2).start();
-    });
+    openDirectory.setOnAction(event -> new Thread(task2).start());
     MenuItem revertChanges = new MenuItem("Revert Changes");
     revertChanges.setOnAction(event -> {
       try {
@@ -1720,6 +1757,33 @@ public class MenuController {
       }
       files.remove();
       changedFiles.getItems().add(file);
+    }
+  }
+
+  private void initRecordingComboboxes() {
+    try {
+      CPUFlags.verify0010FilesConsistent(uncompressedDirectory);
+      int flag = CPUFlags.getRecordingCPUFlag(uncompressedDirectory);
+      int counterFlag = CPUFlags.getRecordingCounterCPUFlag(uncompressedDirectory);
+      recordingFlag.getItems().add("UNUSED");
+      recordingFlag.getItems().addAll(CPUFlags.CPU_FLAG_TO_ACTION.values());
+      if (flag == -1) {
+        recordingFlag.getSelectionModel().selectFirst();
+      } else {
+        recordingFlag.getSelectionModel().select(CPUFlags.CPU_FLAG_TO_ACTION.get(flag));
+      }
+      recordingCounterFlag.getItems().add("UNUSED");
+      recordingCounterFlag.getItems().addAll(CPUFlags.CPU_FLAG_TO_ACTION.values());
+      if (counterFlag == -1) {
+        recordingCounterFlag.getSelectionModel().selectFirst();
+      } else {
+        recordingCounterFlag.getSelectionModel().select(CPUFlags.CPU_FLAG_TO_ACTION.get(flag));
+      }
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "Unable to Init CPU Flags for Recording", e);
+      Message.error("Unable to Init CPU Flags for Recording", e.getMessage());
+      recordingFlag.setDisable(true);
+      recordingCounterFlag.setDisable(true);
     }
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -58,6 +58,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
+import javafx.event.ActionEvent;
 import javafx.event.EventTarget;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -488,6 +489,16 @@ public class MenuController {
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, "Failed to Apply Zabuza Phantom Sword Fix", e);
       Message.error("Failed to Apply Zabuza Phantom Sword Fix", e.getMessage());
+    }
+  }
+
+  @FXML
+  public void fixRecordingTextSize() {
+    try {
+      CPUFlags.fixRecordingTextSize(uncompressedDirectory.resolve(DOL));
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error Fixing Recording Text Size", e);
+      Message.error("Error Fixing Recording Text Size", e.getMessage());
     }
   }
 
@@ -1785,7 +1796,7 @@ public class MenuController {
       if (counterFlag == -1) {
         recordingCounterFlag.getSelectionModel().selectFirst();
       } else {
-        recordingCounterFlag.getSelectionModel().select(CPUFlags.CPU_FLAG_TO_ACTION.get(flag));
+        recordingCounterFlag.getSelectionModel().select(CPUFlags.CPU_FLAG_TO_ACTION.get(counterFlag));
       }
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "Unable to Init CPU Flags for Recording", e);

--- a/src/main/java/com/github/nicholasmoser/gnt4/cpu/CPUFlags.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/cpu/CPUFlags.java
@@ -1,0 +1,216 @@
+package com.github.nicholasmoser.gnt4.cpu;
+
+import static java.util.Map.entry;
+
+import com.github.nicholasmoser.gnt4.seq.Seqs;
+import com.github.nicholasmoser.utils.ByteUtils;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class CPUFlags {
+
+  /**
+   * Offset in the chr 0010.seq files where the branches for CPU flag actions are.
+   */
+  public static final int CPU_BRANCHES_OFFSET = 0x27C;
+
+  /**
+   * Offset in the chr 0010.seq files where the recording code is at.
+   */
+  public static final int RECORDING_OFFSET = 0xF50;
+
+  /**
+   * Offset in the chr 0010.seq files where the recording counter code is at.
+   */
+  public static final int RECORDING_COUNTER_OFFSET = 0x140C;
+
+  /**
+   * The branch at offset 0x10 in the branch table for chr/obo and chr/ta2
+   */
+  public static final int OBO_TA2_SPECIFIC_OFFSET = 0x30A8;
+
+  /**
+   * Each index is the CPU flag and each int is the offset to branch to for that action. Only the
+   * characters obo and ta2 are different for CPU flag 0x10.
+   */
+  public static final List<Integer> CPU_BRANCHES = List.of(0x0344,
+      0x03B8,
+      0x05B8,
+      0x1BC0,
+      0x1CB8,
+      0x1D40,
+      0x1DC0,
+      0x1E08,
+      0x1EB8,
+      0x1F0C,
+      0x1F10,
+      0x1F14,
+      0x1F18,
+      0x1F1C,
+      0x1F20,
+      0x1F24,
+      0x2E34, // Note: This is 0x30A8 for obo and ta2, see OBO_TA2_SPECIFIC_OFFSET
+      0x09F8,
+      0x0A58,
+      0x0AEC,
+      0x0B60,
+      0x0C44,
+      0x0CF4,
+      0x0DD0,
+      0x0E84,
+      0x0EB4,
+      0x0EE4,
+      0x0F14,
+      0x0F4C,
+      0x1408,
+      0x1910,
+      0x1988,
+      0x1AE0,
+      0x1B64,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B84,
+      0x1B88);
+
+  /**
+   * Matches CPU flags to their CPU action description.
+   */
+  public static SortedMap<Integer, String> CPU_FLAG_TO_ACTION = new TreeMap<>(
+      Map.ofEntries(entry(0x11, "Stand"), entry(0x12, "Jump"), entry(0x13, "2P Control"),
+          entry(0x14, "Approach and Throw"), entry(0x15, "Substitution Jutsu"),
+          entry(0x16, "Tech Roll Recovery"), entry(0x17, "Quick Stun Recovery"),
+          entry(0x18, "COM Difficulty Lv1"), entry(0x19, "COM Difficulty Lv2"),
+          entry(0x1A, "COM Difficulty Lv3"), entry(0x1B, "COM Difficulty Lv4")));
+
+  /**
+   * Verify that the branch table for all chr 0010.seq files are consistent. Throws an IOException
+   * if an error is encountered reading the files or the branch tables are not consistent.
+   *
+   * @param uncompressedDir The uncompressed directory.
+   * @throws IOException If any I/O exception occurs.
+   */
+  public static void verify0010FilesConsistent(Path uncompressedDir) throws IOException {
+    int recordingCPUFlag = getRecordingCPUFlag(uncompressedDir);
+    int recordingCounterCPUFlag = getRecordingCounterCPUFlag(uncompressedDir);
+    for (String chr0010 : Seqs.CHRS_0010) {
+      Path chr0010File = uncompressedDir.resolve(chr0010);
+      try (RandomAccessFile raf = new RandomAccessFile(chr0010File.toFile(), "r")) {
+        raf.seek(CPU_BRANCHES_OFFSET);
+        for (int i = 0; i < CPU_BRANCHES.size(); i++) {
+          int expectedBranch;
+          if (i == recordingCPUFlag) {
+            expectedBranch = RECORDING_OFFSET;
+          } else if (i == recordingCounterCPUFlag) {
+            expectedBranch = RECORDING_COUNTER_OFFSET;
+          } else if (i == 0x10 && (chr0010.equals(Seqs.OBO_0010) || chr0010.equals(
+              Seqs.TA2_0010))) {
+            expectedBranch = OBO_TA2_SPECIFIC_OFFSET;
+          } else {
+            expectedBranch = CPU_BRANCHES.get(i);
+          }
+          int actualBranch = ByteUtils.readInt32(raf);
+          if (expectedBranch != actualBranch) {
+            throw new IOException(
+                String.format("Expected branch %d in file %s but was %d", expectedBranch,
+                    chr0010File, actualBranch));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the index in Anko's 0010.seq file branch table where the recording offset is set.
+   * Returns -1 if the recording offset is not being used.
+   *
+   * @param uncompressedDir The uncompressed directory.
+   * @return The index of the recording offset or -1 if it is not being used.
+   * @throws IOException If any I/O exception occurs.
+   */
+  public static int getRecordingCPUFlag(Path uncompressedDir) throws IOException {
+    Path ank0010 = uncompressedDir.resolve(Seqs.ANK_0010);
+    try (RandomAccessFile raf = new RandomAccessFile(ank0010.toFile(), "r")) {
+      raf.seek(CPU_BRANCHES_OFFSET);
+      for (int i = 0; i < CPU_BRANCHES.size(); i++) {
+        if (ByteUtils.readInt32(raf) == RECORDING_OFFSET) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Returns the index in Anko's 0010.seq file branch table where the recording counter offset is
+   * set. Returns -1 if the recording counter offset is not being used.
+   *
+   * @param uncompressedDir The uncompressed directory.
+   * @return The index of the recording counter offset or -1 if it is not being used.
+   * @throws IOException If any I/O exception occurs.
+   */
+  public static int getRecordingCounterCPUFlag(Path uncompressedDir) throws IOException {
+    Path ank0010 = uncompressedDir.resolve(Seqs.ANK_0010);
+    try (RandomAccessFile raf = new RandomAccessFile(ank0010.toFile(), "r")) {
+      raf.seek(CPU_BRANCHES_OFFSET);
+      for (int i = 0; i < CPU_BRANCHES.size(); i++) {
+        if (ByteUtils.readInt32(raf) == RECORDING_COUNTER_OFFSET) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Sets the branch offset for a specific CPU flag.
+   *
+   * @param uncompressedDir The uncompressed directory.
+   * @param flag The CPU flag (index).
+   * @param offset The branch offset to set.
+   * @throws IOException If any I/O exception occurs.
+   */
+  public static void setCPUFlag(Path uncompressedDir, int flag, int offset) throws IOException {
+    if (flag < 0 || flag >= CPU_BRANCHES.size()) {
+      throw new IllegalArgumentException("Flag " + flag + " is outside of allowed range");
+    }
+    for (String chr0010 : Seqs.CHRS_0010) {
+      Path chr0010File = uncompressedDir.resolve(chr0010);
+      try (RandomAccessFile raf = new RandomAccessFile(chr0010File.toFile(), "rw")) {
+        raf.seek(CPU_BRANCHES_OFFSET + (flag * 4L));
+        raf.write(ByteUtils.fromInt32(offset));
+      }
+    }
+  }
+
+  /**
+   * Gets the CPU flag index from an action description.
+   *
+   * @param action The action description.
+   * @return The CPU flag index.
+   */
+  public static int actionToCPUFlag(String action) {
+    for (Entry<Integer, String> entry : CPUFlags.CPU_FLAG_TO_ACTION.entrySet()) {
+      if (action.equals(entry.getValue())) {
+        return entry.getKey();
+      }
+    }
+    throw new IllegalArgumentException(action + " action not found");
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/cpu/CPUFlags.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/cpu/CPUFlags.java
@@ -213,4 +213,19 @@ public class CPUFlags {
     }
     throw new IllegalArgumentException(action + " action not found");
   }
+
+  /**
+   * Fixes the recording text size in the dol. This byte is a bit field of text properties for the
+   * recording text (and maybe other text???). The existing bit flag is 0x80. We are adding 0x20,
+   * therefore the new bit field is 0xA0.
+   *
+   * @param dol The dol to fix.
+   * @throws IOException If any I/O exception occurs.
+   */
+  public static void fixRecordingTextSize(Path dol) throws IOException {
+    try(RandomAccessFile raf = new RandomAccessFile(dol.toFile(), "rw")) {
+      raf.seek(0x8D337);
+      raf.write(0xA0);
+    }
+  }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/Seqs.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/Seqs.java
@@ -269,6 +269,20 @@ public class Seqs {
           S_01, S_02, S_03, S_04, S_05, S_06, S_07, S_08, S_09, S_0E, S_10, S_11, S_12, S_13, S_14,
           S_15, S_16, S_17, S_18, S_19, S_1E, S_20, S_21, S_22, S_23, S_24);
 
+  public static final List<String> CHRS_0000 = List
+      .of(ANK_0000, BOU_0000, CHO_0000, DOG_0000, GAI_0000, GAR_0000, HAK_0000, HI2_0000, HIN_0000,
+          INO_0000, IRU_0000, ITA_0000, JIR_0000, KAB_0000, KAK_0000, KAN_0000, KAR_0000, KIB_0000,
+          KID_0000, KIM_0000, KIS_0000, LOC_0000, MIZ_0000, NA9_0000, NAR_0000, NEJ_0000, OBO_0000,
+          ORO_0000, SA2_0000, SAK_0000, SAR_0000, SAS_0000, SIK_0000, SIN_0000, SKO_0000, TA2_0000,
+          TAY_0000, TEM_0000, TEN_0000, TSU_0000, ZAB_0000);
+
+  public static final List<String> CHRS_0010 = List
+      .of(ANK_0010, BOU_0010, CHO_0010, DOG_0010, GAI_0010, GAR_0010, HAK_0010, HI2_0010, HIN_0010,
+          INO_0010, IRU_0010, ITA_0010, JIR_0010, KAB_0010, KAK_0010, KAN_0010, KAR_0010, KIB_0010,
+          KID_0010, KIM_0010, KIS_0010, LOC_0010, MIZ_0010, NA9_0010, NAR_0010, NEJ_0010, OBO_0010,
+          ORO_0010, SA2_0010, SAK_0010, SAR_0010, SAS_0010, SIK_0010, SIN_0010, SKO_0010, TA2_0010,
+          TAY_0010, TEM_0010, TEN_0010, TSU_0010, ZAB_0010);
+
   /**
    * Tries to find the unique path name of the SEQ file from the given SEQ path. Will return an
    * empty optional in such cases as the SEQ file being renamed.

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -313,7 +313,8 @@
                      <RowConstraints vgrow="SOMETIMES" />
                    <RowConstraints vgrow="SOMETIMES" />
                      <RowConstraints vgrow="SOMETIMES" />
-                     <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                     <RowConstraints vgrow="SOMETIMES" />
+                     <RowConstraints vgrow="SOMETIMES" />
                  </rowConstraints>
                   <children>
                 <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#applyZTKDamageMultiplier" prefWidth="217.0" text="Apply" GridPane.columnIndex="2" GridPane.rowIndex="1">
@@ -409,7 +410,7 @@
                            <Insets bottom="8.0" left="8.0" top="8.0" />
                         </GridPane.margin>
                      </Text>
-                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording" GridPane.rowIndex="6">
+                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording" GridPane.rowIndex="7">
                         <font>
                            <Font size="16.0" />
                         </font>
@@ -417,17 +418,17 @@
                            <Insets left="8.0" />
                         </GridPane.margin>
                      </Text>
-                     <ComboBox fx:id="recordingFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingFlag" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                     <ComboBox fx:id="recordingFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingFlag" GridPane.columnIndex="1" GridPane.rowIndex="7">
                         <GridPane.margin>
                            <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
                         </GridPane.margin>
                      </ComboBox>
-                     <ComboBox fx:id="recordingCounterFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingCounterFlag" GridPane.columnIndex="1" GridPane.rowIndex="7">
+                     <ComboBox fx:id="recordingCounterFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingCounterFlag" GridPane.columnIndex="1" GridPane.rowIndex="8">
                         <GridPane.margin>
                            <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
                         </GridPane.margin>
                      </ComboBox>
-                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording/Counter" GridPane.rowIndex="7">
+                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording/Counter" GridPane.rowIndex="8">
                         <font>
                            <Font size="16.0" />
                         </font>
@@ -435,6 +436,22 @@
                            <Insets left="8.0" />
                         </GridPane.margin>
                      </Text>
+                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Recording Text Size" GridPane.rowIndex="6">
+                        <font>
+                           <Font size="16.0" />
+                        </font>
+                        <GridPane.margin>
+                           <Insets left="8.0" />
+                        </GridPane.margin>
+                     </Text>
+                     <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#fixRecordingTextSize" text="Apply" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                        <font>
+                           <Font size="16.0" />
+                        </font>
+                        <GridPane.margin>
+                           <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
+                        </GridPane.margin>
+                     </Button>
                   </children>
                </GridPane>
         </AnchorPane>

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -312,6 +312,8 @@
                      <RowConstraints vgrow="SOMETIMES" />
                      <RowConstraints vgrow="SOMETIMES" />
                    <RowConstraints vgrow="SOMETIMES" />
+                     <RowConstraints vgrow="SOMETIMES" />
+                     <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                  </rowConstraints>
                   <children>
                 <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#applyZTKDamageMultiplier" prefWidth="217.0" text="Apply" GridPane.columnIndex="2" GridPane.rowIndex="1">
@@ -405,6 +407,32 @@
                         </font>
                         <GridPane.margin>
                            <Insets bottom="8.0" left="8.0" top="8.0" />
+                        </GridPane.margin>
+                     </Text>
+                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording" GridPane.rowIndex="6">
+                        <font>
+                           <Font size="16.0" />
+                        </font>
+                        <GridPane.margin>
+                           <Insets left="8.0" />
+                        </GridPane.margin>
+                     </Text>
+                     <ComboBox fx:id="recordingFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingFlag" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                        <GridPane.margin>
+                           <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
+                        </GridPane.margin>
+                     </ComboBox>
+                     <ComboBox fx:id="recordingCounterFlag" maxWidth="1.7976931348623157E308" onAction="#setRecordingCounterFlag" GridPane.columnIndex="1" GridPane.rowIndex="7">
+                        <GridPane.margin>
+                           <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
+                        </GridPane.margin>
+                     </ComboBox>
+                     <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="CPU Option Set to Recording/Counter" GridPane.rowIndex="7">
+                        <font>
+                           <Font size="16.0" />
+                        </font>
+                        <GridPane.margin>
+                           <Insets left="8.0" />
                         </GridPane.margin>
                      </Text>
                   </children>

--- a/src/test/java/com/github/nicholasmoser/gnt4/cpu/CPUFlagsTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/cpu/CPUFlagsTest.java
@@ -1,0 +1,22 @@
+package com.github.nicholasmoser.gnt4.cpu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.nicholasmoser.testing.Prereqs;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+public class CPUFlagsTest {
+
+  @Test
+  public void testRecordingFlagChecks() throws Exception {
+    Path uncompressed = Prereqs.getUncompressedGNT4();
+    CPUFlags.verify0010FilesConsistent(uncompressed);
+    assertEquals(-1, CPUFlags.getRecordingCPUFlag(uncompressed));
+    assertEquals(-1, CPUFlags.getRecordingCounterCPUFlag(uncompressed));
+    assertEquals(0x11, CPUFlags.actionToCPUFlag("Stand"));
+    assertEquals(0x17, CPUFlags.actionToCPUFlag("Quick Stun Recovery"));
+    assertThrows(IllegalArgumentException.class, () -> CPUFlags.actionToCPUFlag("test"));
+  }
+}


### PR DESCRIPTION
Implements https://github.com/NicholasMoser/GNTool/issues/106

Much like Eighting's other title Bloody Roar, Naruto GNT4 also has recording functionality in its training mode. However in GNT4 this recording functionality is disabled. This pull request allows you to add it back into the game by replacing a training mode CPU option.

![image](https://user-images.githubusercontent.com/4983605/173720426-604967dc-3700-442a-8053-461a17f1e14e.png)

First, I've added a button called **Fix Recording Text Size**. It is necessary to press this button at least once to add a new bit field to the DOL to process the recording text with the correct size. Then, like the image above shows, select a CPU option such as **Stand** and **Jump** to replace with **Recording** and **Recording/Counter**.

Recording can be enabled by pressing down on the C-stick. Then you can control your opponent as you wish. When done, press down on the C-stick again to save the inputs. Then press down on the C-stick again to play the inputs back on the opponent. Press C-stick again to stop them and reset the recording.

The difference between **Recording** and **Recording/Counter** is that when you playback **Recording** the opponent will immediately execute your inputs. With **Recording/Counter** they will only execute the inputs after being hit (blocked and unblocked).

Example of recording functionality: https://imgur.com/a/cZkqPXJ

Other notes:

- This does not replace the text of the CPU option in the menu. If you wish to change the text you can do so at 0x801ff854 (offset 0x1FC854 in `main.dol`).
- Replacing the CPU Level options may break that CPU Level for the character even outside of training mode
- Vanilla GNT4 does not have every English character available, so many characters will not display. The characters are English ASCII in each character's 0010.seq file. I may add functionality to fix this in a later PR.