### PR TITLE
Add permissive SEQ disassembling

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/DolphinSeqListener.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/DolphinSeqListener.java
@@ -344,7 +344,7 @@ public class DolphinSeqListener {
               return null;
             }
           }
-          SeqKing.generateHTML(seqPath, fileName.get(), outputHTML, false);
+          SeqKing.generateHTML(seqPath, fileName.get(), outputHTML, false, true);
         }
         int offset = Integer.decode("0x" + message.substring(0, 8));
         String fileUri = "file:///" + outputHTML + String.format("#%X", offset);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
@@ -82,7 +82,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
@@ -4,6 +4,7 @@ import com.github.nicholasmoser.gnt4.seq.comment.Function;
 import com.github.nicholasmoser.gnt4.seq.comment.Functions;
 import com.github.nicholasmoser.gnt4.seq.opcodes.BinaryData;
 import com.github.nicholasmoser.gnt4.seq.opcodes.BranchingOpcode;
+import com.github.nicholasmoser.gnt4.seq.opcodes.InvalidBytes;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
 import com.github.nicholasmoser.utils.ByteStream;
 import java.io.IOException;
@@ -153,9 +154,9 @@ public class SeqKing {
         newOpcode = SeqHelper.getSeqOpcode(bs, opcodeGroup, opcode);
       } catch (Exception e) {
         if (permissive) {
-          // Invalid opcode, mark it as binary data and continue
+          // Invalid opcode, mark it as invalid bytes and continue
           bs.seek(tempOffset);
-          newOpcode = new BinaryData(tempOffset, bs.readNBytes(4));
+          newOpcode = new InvalidBytes(tempOffset, bs.readNBytes(4));
         } else {
           throw e;
         }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/InvalidBytes.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/opcodes/InvalidBytes.java
@@ -1,0 +1,62 @@
+package com.github.nicholasmoser.gnt4.seq.opcodes;
+
+import static j2html.TagCreator.attrs;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+
+public class InvalidBytes implements Opcode {
+
+  private final static String MNEMONIC = "invalid_bytes";
+  private final int offset;
+  private final byte[] bytes;
+  private final String info;
+
+  public InvalidBytes(int offset, byte[] bytes) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = "";
+  }
+
+  public InvalidBytes(int offset, byte[] bytes, String info) {
+    this.offset = offset;
+    this.bytes = bytes;
+    this.info = info;
+  }
+
+  @Override
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public byte[] getBytes(int offset, int size) {
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%05X | %s 0x%X bytes %s %s", offset, MNEMONIC, bytes.length, info, formatRawBytes(bytes));
+  }
+
+  @Override
+  public String toAssembly() {
+    return String.format("%s",MNEMONIC);
+  }
+
+  @Override
+  public String toAssembly(int offset) {
+    return toAssembly();
+  }
+
+  @Override
+  public ContainerTag toHTML() {
+    String id = String.format("#%X", offset);
+    return div(attrs(id)).withText(toString());
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/tools/SeqDisassemblerTool.java
+++ b/src/main/java/com/github/nicholasmoser/tools/SeqDisassemblerTool.java
@@ -149,9 +149,9 @@ public class SeqDisassemblerTool {
         try {
           updateMessage(String.format("Disassembling %s", seqPath.getFileName()));
           if (html) {
-            SeqKing.generateHTML(seqPath, fileName, outputFile, false);
+            SeqKing.generateHTML(seqPath, fileName, outputFile, false, true);
           } else {
-            SeqKing.generateTXT(seqPath, fileName, outputFile, false);
+            SeqKing.generateTXT(seqPath, fileName, outputFile, false, true);
           }
           updateMessage("Complete");
           updateProgress(1, 1);

--- a/src/main/java/com/github/nicholasmoser/utils/ByteStream.java
+++ b/src/main/java/com/github/nicholasmoser/utils/ByteStream.java
@@ -122,14 +122,11 @@ public class ByteStream extends ByteArrayInputStream {
    * @param num The number of bytes to read.
    * @return The bytes read in an array.
    * @throws IOException If an I/O error occurs.
+   * @deprecated why did I write this, there's already a readNBytes
    */
+  @Deprecated
   public byte[] readBytes(int num) throws IOException {
-    int startingOffset = pos;
-    byte[] bytes = new byte[num];
-    if (read(bytes) != num) {
-      throw new IOException(String.format("Failed to read %d bytes at offset %d", num, startingOffset));
-    }
-    return bytes;
+    return readNBytes(num);
   }
 
   /**

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -14,6 +14,7 @@ public class SeqKingTest {
   // For unit testing: compare mode is off, verbose is off, and output files are deleted
   private static final boolean COMPARE_MODE = false;
   private static final boolean VERBOSE = false;
+  private static final boolean PERMISSIVE = false;
   private static final boolean DELETE_FILE = true;
 
   @Test
@@ -532,7 +533,7 @@ public class SeqKingTest {
       String output = seq.toString().replace(".seq", "_test.html");
       outputPath = Paths.get(output);
       Optional<String> fileName = Seqs.getFileName(seq);
-      SeqKing.generateHTML(seq, fileName.get(), outputPath, VERBOSE);
+      SeqKing.generateHTML(seq, fileName.get(), outputPath, VERBOSE, PERMISSIVE);
       String expected = seq.toString().replace(".seq", ".html");
       Path expectedPath = Paths.get(expected);
       byte[] expectedBytes = Files.readAllBytes(expectedPath);
@@ -551,7 +552,7 @@ public class SeqKingTest {
       String output = seq.toString().replace(".seq", ".html");
       outputPath = Paths.get(output);
       Optional<String> fileName = Seqs.getFileName(seq);
-      SeqKing.generateHTML(seq, fileName.get(), outputPath, VERBOSE);
+      SeqKing.generateHTML(seq, fileName.get(), outputPath, VERBOSE, PERMISSIVE);
     } finally {
       if (DELETE_FILE && outputPath != null) {
         Files.deleteIfExists(outputPath);


### PR DESCRIPTION
Some mods like SCON4 directly modified the bytes in the SEQ files. Opcodes are variable length, and in some cases these modifications result in broken opcodes (e.g. 4 bytes of an 8 byte opcode were overridden). This will fail to be parsed by the SEQ report disassembler.

This PR adds in the ability to allow SEQ parsing to be permissive. By default, all SEQ parsing initiated by the GUI will be permissive. All SEQ parsing done for unit testing will not be, to make it easier to add support for new opcodes.

Example:
![image](https://user-images.githubusercontent.com/4983605/177013222-4f2cb12c-0bd5-460e-a6f2-259bba1b8506.png)
