### PR TITLE
Remove extra comma from known_codes.json

### DIFF
--- a/src/main/resources/com/github/nicholasmoser/gnt4/dol/known_codes.json
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/dol/known_codes.json
@@ -212,7 +212,6 @@
     ],
     "name": "Add Random Select to Character Select Screen [Nick]"
   },
-  ,
   {
     "codes": [
       {


### PR DESCRIPTION
When attempting to create a new workspace from an existing ISO with Gecko codes, you will get the following error:

```
SEVERE: Error getting list of applied codes.
org.json.JSONException: JSONArray[15] is not a JSONObject.
	at org.json@20220320/org.json.JSONArray.wrongValueFormatException(JSONArray.java:1694)
	at org.json@20220320/org.json.JSONArray.getJSONObject(JSONArray.java:481)
	at com.github.nicholasmoser@4.3.0-SNAPSHOT/com.github.nicholasmoser.gnt4.dol.DolHijack.findCodeMatch(DolHijack.java:204)
	at com.github.nicholasmoser@4.3.0-SNAPSHOT/com.github.nicholasmoser.gnt4.dol.DolHijack.handleActiveCodesButNoCodeFile(DolHijack.java:122)
	at com.github.nicholasmoser@4.3.0-SNAPSHOT/com.github.nicholasmoser.gnt4.MenuController.lambda$refreshActiveCodes$17(MenuController.java:1641)
	at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
	at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
	at javafx.graphics/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
	at javafx.graphics/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This is because there is an extra comma in the known_codes.json file. This PR fixes that.