### PR TITLE
Workspace Files Fixes

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gecko/GeckoCodeJSON.java
+++ b/src/main/java/com/github/nicholasmoser/gecko/GeckoCodeJSON.java
@@ -18,6 +18,8 @@ import org.json.JSONTokener;
  */
 public class GeckoCodeJSON {
 
+  // The path to codes.json file when it is bundled with the ISO
+  public static final String PACKED_CODE_FILE_PATH = "cmn/codes.json";
   public static final String CODE_FILE = "codes.json";
 
   /**

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -1953,7 +1953,7 @@ public class MenuController {
    * @return The codes.json path, preferring uncompressed/files/codes.json
    */
   private Path getCodesFile() {
-    Path codePath = uncompressedFiles.resolve(GeckoCodeJSON.CODE_FILE);
+    Path codePath = uncompressedFiles.resolve(GeckoCodeJSON.PACKED_CODE_FILE_PATH);
     if (Files.exists(codePath)) {
       return codePath;
     }

--- a/src/main/java/com/github/nicholasmoser/iso/ISOCreator.java
+++ b/src/main/java/com/github/nicholasmoser/iso/ISOCreator.java
@@ -39,7 +39,7 @@ public class ISOCreator {
   public void create(boolean pushFilesToEnd) throws IOException {
     DirectoryParser parser = new DirectoryParser(inputPath, pushFilesToEnd);
     ISOHeader isoHeader = parser.getISOHeader();
-    create(isoHeader);
+    create(pushFilesToEnd, isoHeader);
   }
 
   /**
@@ -48,8 +48,13 @@ public class ISOCreator {
    * @param isoHeader The ISOHeader for the ISO.
    * @throws IOException If an I/O error occurs.
    */
-  public void create(ISOHeader isoHeader)
+  public void create(boolean pushFilesToEnd, ISOHeader isoHeader)
       throws IOException {
+    // Rewrite the fst.bin and get a new ISOHeader afterwards
+    FileSystemTable.rewrite(inputPath, isoHeader);
+    DirectoryParser parser = new DirectoryParser(inputPath, pushFilesToEnd);
+    isoHeader = parser.getISOHeader();
+
     // Get values for files in the sys folder
     Path apploaderImgPath = resolve("sys/apploader.img");
     Path bi2BinPath = resolve("sys/bi2.bin");
@@ -64,8 +69,7 @@ public class ISOCreator {
     int fstOffset = fstBin.getPos();
     int fstSize = fstBin.getLen();
 
-    // Rewrite the fst.bin and offsets/sizes in the boot.bin
-    FileSystemTable.rewrite(inputPath, isoHeader);
+    // Write offsets/sizes to the boot.bin
     bootBinRewrite(bootBinPath, dolOffset, fstOffset, fstSize);
 
     // Write out the ISO

--- a/src/test/java/com/github/nicholasmoser/iso/DuplicateISOTest.java
+++ b/src/test/java/com/github/nicholasmoser/iso/DuplicateISOTest.java
@@ -99,7 +99,7 @@ public class DuplicateISOTest {
     DirectoryParser dirParser = new DirectoryParser(testDirectory, true);
     ISOHeader isoHeader = dirParser.getISOHeader();
     ISOCreator creator = new ISOCreator(testDirectory, testIso);
-    creator.create(isoHeader);
+    creator.create(true, isoHeader);
     validateISO(testIso);
   }
 

--- a/src/test/java/com/github/nicholasmoser/iso/FileSystemTableTest.java
+++ b/src/test/java/com/github/nicholasmoser/iso/FileSystemTableTest.java
@@ -1,0 +1,21 @@
+package com.github.nicholasmoser.iso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.nicholasmoser.testing.Prereqs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class FileSystemTableTest {
+  @Test
+  public void vanillaFileSystemCanBeRead() throws Exception {
+    Path uncompressed = Prereqs.getUncompressedGNT4();
+    Path fst = uncompressed.resolve("sys/fst.bin");
+    List<ISOItem> items = FileSystemTable.read(fst);
+    assertThat(items.size()).isEqualTo(563);
+    assertThat(Files.size(fst)).isEqualTo(0x33E7);
+    assertThat(items).doesNotContainNull();
+  }
+}


### PR DESCRIPTION
This PR fixes two issues.

1. The order of building the ISO causes issues when new files have been added to the workspace. This is because the ISOHeader is created, the file system table is updated, and then the ISO is built. The issue is that updating the file system table changes the size of the file if new files have been added. Therefore the order is now: create the ISOHeader, update the file system table, create a new ISOHeader, then build the ISO. We must create the ISOHeader twice because it is required the first time to update the file system table.
2. When the codes.json exists at the root directory of ISO files, it causes issues in Dolphin. That is, Dolphin fails to read the banner data (`opening.bnr`) which is also stored at the root directory of ISO files.

**Expected**
![image](https://user-images.githubusercontent.com/4983605/186069356-0cff53de-a36b-43d9-a7be-8cd3086763dc.png)

**Actual**
![image](https://user-images.githubusercontent.com/4983605/186069441-15d1a7e6-ac70-4ad7-8fd1-28fbb052eee7.png)

This is fixed by moving the `codes.json` somewhere else. It has now been moved to `cmn/codes.json`.