### PR TITLE
Add Duplicate Costume Fix

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -132,6 +132,7 @@ public class MenuController {
   public Button removeCode;
   public ComboBox<String> recordingFlag;
   public ComboBox<String> recordingCounterFlag;
+  public CheckBox fixCostumeDuplicateCheck;
 
   /**
    * Toggles the code for fixing the audio.
@@ -284,6 +285,11 @@ public class MenuController {
       LOGGER.log(Level.SEVERE, "Failed to Allow Duplicate Characters in 4-Player Mode", e);
       Message.error("Failed to apply patch.", e.getMessage());
     }
+  }
+
+  @FXML
+  public void fixCostumeDuplicateCheck() {
+    System.out.println(fixCostumeDuplicateCheck.isSelected());
   }
 
   @FXML

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Comments.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Comments.java
@@ -189,6 +189,7 @@ public class Comments {
     charSelComments.put(0x2370, "// Stage IDs");
     charSelComments.put(0x23F0, "// Stage Display IDs");
     charSelComments.put(0x3A14, "// Costume ID is read here, 7FFFFF3D is the costume_id");
+    charSelComments.put(0x5680, "// If opponent costume is 1 or 3, goto offset 0x56B4");
     charSelComments.put(0x572C, "// Models specific for costumes 3 and 4 here (Sakura, Ino only)");
     charSelComments.put(0x690C, "// Set the costume_id to 7FFFFF3D");
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Functions.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Functions.java
@@ -160,6 +160,11 @@ public class Functions {
     functions = getChrBaseFunctions(Seqs.ZAB_0000);
     allFunctions.put(Seqs.ZAB_0000, functions);
 
+    functions = new HashMap<>();
+    functions.put(0x5670, new Function("change_duplicate_costume",
+        List.of("// Change costume if duplicate costume is selected", "7FFFFF25: Opponent costume offset", "7FFFFF24: This costume offset")));
+    allFunctions.put(Seqs.CHARSEL, functions);
+
     return allFunctions;
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3C.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3C.java
@@ -11,6 +11,7 @@ public class OpcodeGroup3C {
       case 0x00 -> UnknownOpcode.of(0xc, bs);
       case 0x01 -> UnknownOpcode.of(0xc, bs);
       case 0x02 -> UnknownOpcode.of(0xc, bs);
+      case 0x03 -> UnknownOpcode.of(0xc, bs); // Not in GNT4
       case 0x04 -> UnknownOpcode.of(0xc, bs);
       case 0x05 -> UnknownOpcode.of(0xc, bs);
       case 0x06 -> UnknownOpcode.of(0xc, bs);

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
@@ -9,8 +9,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.application.Platform;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 
@@ -74,6 +76,7 @@ public class CostumeController {
     List<String> costumes4 = costume4.getItems();
     try {
       verifyIntegrity(costumes3, costumes4);
+      checkDupeCostumeFix(charSel);
       if (hasCodes) {
         // Codes already exist, delete them before adding new codes
         CostumeExtender.removeCodes(charSel, charSel4);
@@ -87,6 +90,22 @@ public class CostumeController {
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "Failed to write costume bytes", e);
       Message.info("Failed to write costume bytes", e.getMessage());
+    }
+  }
+
+  private void checkDupeCostumeFix(Path charSel) throws IOException {
+    List<SeqEdit> edits = SeqExt.getEdits(charSel);
+    if (!DupeCostumeFix.isEnabled(edits)) {
+      String msg = """
+            The code "Fix Costume Duplicate Check" is not currently applied.
+            Without it, costumes 1 and 3, and 2 and 4 cannot fight each other when players select
+            the same character. Also, crashes can occur when the default game logic attempts to
+            fallback to costume 4 if it does not exist.
+            Would you like to enable the duplicate costume fix in order to fix this behavior?
+            """;
+      if (Message.warnConfirmation("Missing Dupe Costume Fix", msg)) {
+        DupeCostumeFix.enable(charSel);
+      }
     }
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/DupeCostumeFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/DupeCostumeFix.java
@@ -1,0 +1,215 @@
+package com.github.nicholasmoser.gnt4.ui;
+
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEdit;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEditBuilder;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqExt;
+import com.github.nicholasmoser.utils.ByteUtils;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A class used to fix the duplicate costume logic in GNT4.
+ * <p>
+ * The existing code of the game treats costumes 1 and 3 as identical. Same for 2 and 4. It probably
+ * does this since the clothes are the same (despite face/hair changing). Also, when the code
+ * detects a duplicate costume it goes from costume 1->2, 2->1, 3->4, 4->3.
+ * <p>
+ * Both of these behaviors are an issue. Going from 3->4 crashes if there's no costume 4. Also, you
+ * can't have costume 1 and 3 fight each other because the game thinks they're duplicates. Same for
+ * 2 and 4. I fixed this by writing new code that overwrites the existing behavior 1 and 3, 2 and 4
+ * are no longer considered duplicates Also, 3 no longer falls back to 4 in case of duplicate, now
+ * it goes to 2
+ */
+public class DupeCostumeFix {
+
+  private static final String EXT_PARAM_1_NAME = "Fix Costume Duplicate Check (extension_parameters_1)";
+  private static final int EXT_PARAM_1_OFFSET = 0x5798;
+  private static final int EXT_PARAM_1_LENGTH = 0x18;
+  private static final byte[] EXT_PARAM_1_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C010000 0000000C 7FFFFF2D
+      3C010000 0000000F 7FFFFF2E
+      3C010000 00000006 7FFFFF24
+      3C010000 00000009 7FFFFF25
+      """);
+
+  private static final String EXT_PARAM_2_NAME = "Fix Costume Duplicate Check (extension_parameters_2)";
+  private static final int EXT_PARAM_2_OFFSET = 0x57E4;
+  private static final int EXT_PARAM_2_LENGTH = 0x18;
+  private static final byte[] EXT_PARAM_2_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C010000 0000000F 7FFFFF2D
+      3C010000 0000000C 7FFFFF2E
+      3C010000 00000009 7FFFFF24
+      3C010000 00000006 7FFFFF25
+      """);
+
+  private static final String EXT_PARAM_3_NAME = "Fix Costume Duplicate Check (extension_parameters_3)";
+  private static final int EXT_PARAM_3_OFFSET = 0x916C;
+  private static final int EXT_PARAM_3_LENGTH = 0x18;
+  private static final byte[] EXT_PARAM_3_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C000000 0000000F 7FFFFF2D
+      3C000000 0000000C 7FFFFF2E
+      3C000000 00000009 7FFFFF24
+      3C000000 00000006 7FFFFF25
+      """);
+
+  private static final String EXT_PARAM_4_NAME = "Fix Costume Duplicate Check (extension_parameters_4)";
+  private static final int EXT_PARAM_4_OFFSET = 0x548C;
+  private static final int EXT_PARAM_4_LENGTH = 0x18;
+  private static final byte[] EXT_PARAM_4_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C000000 0000000C 7FFFFF2D
+      3C000000 0000000F 7FFFFF2E
+      3C000000 00000006 7FFFFF24
+      3C000000 00000009 7FFFFF25
+      """);
+
+  private static final String COMPARE_VALUES_NAME = "Fix Costume Duplicate Check (compare_values)";
+  private static final int COMPARE_VALUES_OFFSET = 0x5670;
+  private static final int COMPARE_VALUES_LENGTH = 0x10;
+  private static final byte[] COMPARE_VALUES_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C160000 0000F530 7FFFFF2D 7FFFFF27
+      3C160000 0000F530 7FFFFF2E 7FFFFF2E
+      3B020000 000056C4 7FFFFF27 7FFFFF2E
+      3C160000 0000F530 7FFFFF24 7FFFFF27
+      3C160000 0000F530 7FFFFF25 7FFFFF25
+      3C030000 00000001 7FFFFF27
+      3C030000 00000001 7FFFFF25
+      3B020000 000056C4 7FFFFF27 7FFFFF25
+      3B010000 00005680 7FFFFF2E 00000000
+      3B020000 00005680 7FFFFF25 00000000
+      3C170000 0000F530 7FFFFF2D 00000000
+      """);
+
+  private static final String NORMAL_FLOW_NAME = "Fix Costume Duplicate Check (normal_flow)";
+  private static final int NORMAL_FLOW_OFFSET = 0x5680;
+  private static final int NORMAL_FLOW_LENGTH = 0x10;
+  private static final byte[] NORMAL_FLOW_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3B010000 000056B4 00000001 7FFFFF25
+      3B010000 000056B4 00000003 7FFFFF25
+      """);
+
+  public static final Set<String> CODES = Set.of(EXT_PARAM_1_NAME, EXT_PARAM_2_NAME,
+      EXT_PARAM_3_NAME, EXT_PARAM_4_NAME, COMPARE_VALUES_NAME, NORMAL_FLOW_NAME);
+
+  /**
+   * Enables the fix on char_sel.seq
+   *
+   * @param charSel The path to char_sel.seq
+   * @throws IOException If an I/O error occurs.
+   */
+  public static void enable(Path charSel) throws IOException {
+    SeqEdit edit = SeqEditBuilder.getBuilder()
+        .name(EXT_PARAM_1_NAME)
+        .newBytes(EXT_PARAM_1_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(EXT_PARAM_1_OFFSET)
+        .endOffset(EXT_PARAM_1_OFFSET + EXT_PARAM_1_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+
+    edit = SeqEditBuilder.getBuilder()
+        .name(EXT_PARAM_2_NAME)
+        .newBytes(EXT_PARAM_2_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(EXT_PARAM_2_OFFSET)
+        .endOffset(EXT_PARAM_2_OFFSET + EXT_PARAM_2_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+
+    edit = SeqEditBuilder.getBuilder()
+        .name(EXT_PARAM_3_NAME)
+        .newBytes(EXT_PARAM_3_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(EXT_PARAM_3_OFFSET)
+        .endOffset(EXT_PARAM_3_OFFSET + EXT_PARAM_3_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+
+    edit = SeqEditBuilder.getBuilder()
+        .name(EXT_PARAM_4_NAME)
+        .newBytes(EXT_PARAM_4_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(EXT_PARAM_4_OFFSET)
+        .endOffset(EXT_PARAM_4_OFFSET + EXT_PARAM_4_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+
+    edit = SeqEditBuilder.getBuilder()
+        .name(COMPARE_VALUES_NAME)
+        .newBytes(COMPARE_VALUES_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(COMPARE_VALUES_OFFSET)
+        .endOffset(COMPARE_VALUES_OFFSET + COMPARE_VALUES_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+
+    edit = SeqEditBuilder.getBuilder()
+        .name(NORMAL_FLOW_NAME)
+        .newBytes(NORMAL_FLOW_NEW_BYTES)
+        .seqPath(charSel)
+        .startOffset(NORMAL_FLOW_OFFSET)
+        .endOffset(NORMAL_FLOW_OFFSET + NORMAL_FLOW_LENGTH)
+        .create();
+    SeqExt.addEdit(edit, charSel);
+  }
+
+  /**
+   * Disables the fix on char_sel.seq
+   *
+   * @param charSel The path to char_sel.seq
+   * @throws IOException If an I/O error occurs.
+   */
+  public static void disable(Path charSel) throws IOException {
+    for (SeqEdit edit : SeqExt.getEdits(charSel)) {
+      if (CODES.contains(edit.getName())) {
+        SeqExt.removeEdit(edit, charSel);
+      }
+    }
+  }
+
+  /**
+   * Returns whether the duplicate costume fix is fully enabled. This method will return false if it
+   * is partially enabled. Use {@link #verifyIntegrity(List)} to see which parts of the fix are
+   * missing.
+   *
+   * @param edits
+   * @return
+   */
+  public static boolean isEnabled(List<SeqEdit> edits) {
+    Set<String> editNames = edits.stream()
+        .map(edit -> edit.getName())
+        .collect(Collectors.toSet());
+    for (String code : CODES) {
+      if (!editNames.contains(code)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * If any part of Fix Costume Duplicate Check is enabled, return any missing codes for it to in
+   * order to verify integrity of the codes.
+   *
+   * @param edits The edits to parse for Fix Costume Duplicate Check.
+   * @return If the code is partially enabled, which parts of the code are missing.
+   */
+  public static Set<String> verifyIntegrity(List<SeqEdit> edits) {
+    Set<String> found = new HashSet<>();
+    for (SeqEdit edit : edits) {
+      if (CODES.contains(edit.getName())) {
+        found.add(edit.getName());
+      }
+    }
+    if (found.isEmpty() || CODES.equals(found)) {
+      return Collections.emptySet();
+    }
+    // Missing some of the dupe costume codes, find which ones
+    return Sets.difference(CODES, found);
+  }
+}

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -601,13 +601,14 @@
                            <RowConstraints vgrow="SOMETIMES" />
                            <RowConstraints vgrow="SOMETIMES" />
                            <RowConstraints vgrow="SOMETIMES" />
+                           <RowConstraints vgrow="SOMETIMES" />
                            <RowConstraints />
                            <RowConstraints />
                            <RowConstraints />
                            <RowConstraints />
                        </rowConstraints>
                         <children>
-                    <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSModelLoad" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="8">
+                    <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSModelLoad" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="9">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -692,7 +693,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Allow duplicate characters in 4-player battles" GridPane.rowIndex="5">
+                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Allow duplicate characters in 4-player battles" GridPane.rowIndex="6">
                               <GridPane.margin>
                                  <Insets left="8.0" />
                               </GridPane.margin>
@@ -700,7 +701,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Text>
-                    <Button maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#allow4pDupeChrs" text="Apply" GridPane.columnIndex="1" GridPane.rowIndex="5">
+                    <Button maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#allow4pDupeChrs" text="Apply" GridPane.columnIndex="1" GridPane.rowIndex="6">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -708,7 +709,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Character Selection Initial Speed" GridPane.rowIndex="6">
+                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Character Selection Initial Speed" GridPane.rowIndex="7">
                               <GridPane.margin>
                                  <Insets left="8.0" />
                               </GridPane.margin>
@@ -716,7 +717,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Text>
-                    <Spinner fx:id="cssInitialSpeed" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssInitialSpeed" onMouseReleased="#setCssInitialSpeed" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                    <Spinner fx:id="cssInitialSpeed" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssInitialSpeed" onMouseReleased="#setCssInitialSpeed" GridPane.columnIndex="1" GridPane.rowIndex="7">
                       <valueFactory>
                         <javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory max="15" min="1" />
                       </valueFactory>
@@ -724,7 +725,7 @@
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
                     </Spinner>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSInitialSpeed" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="6">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSInitialSpeed" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="7">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -732,7 +733,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSInitialSpeed" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="6">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSInitialSpeed" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="7">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -740,7 +741,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Character Selection Max Speed" GridPane.rowIndex="7">
+                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Character Selection Max Speed" GridPane.rowIndex="8">
                               <GridPane.margin>
                                  <Insets left="8.0" />
                               </GridPane.margin>
@@ -748,7 +749,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Text>
-                    <Spinner fx:id="cssMaxSpeed" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssMaxSpeed" onMouseReleased="#setCssMaxSpeed" GridPane.columnIndex="1" GridPane.rowIndex="7">
+                    <Spinner fx:id="cssMaxSpeed" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssMaxSpeed" onMouseReleased="#setCssMaxSpeed" GridPane.columnIndex="1" GridPane.rowIndex="8">
                       <valueFactory>
                         <javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory max="15" min="1" />
                       </valueFactory>
@@ -756,7 +757,7 @@
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
                     </Spinner>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSMaxSpeed" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="7">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#defaultCSSMaxSpeed" text="Default" GridPane.columnIndex="2" GridPane.rowIndex="8">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -764,7 +765,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSMaxSpeed" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="7">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSMaxSpeed" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="8">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -772,7 +773,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Frames Until Character Model is Loaded " GridPane.rowIndex="8">
+                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Frames Until Character Model is Loaded " GridPane.rowIndex="9">
                               <GridPane.margin>
                                  <Insets left="8.0" />
                               </GridPane.margin>
@@ -780,7 +781,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Text>
-                    <Spinner fx:id="cssModelLoad" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssModelLoad" onMouseReleased="#setCssModelLoad" GridPane.columnIndex="1" GridPane.rowIndex="8">
+                    <Spinner fx:id="cssModelLoad" maxWidth="1.7976931348623157E308" onKeyReleased="#setCssModelLoad" onMouseReleased="#setCssModelLoad" GridPane.columnIndex="1" GridPane.rowIndex="9">
                       <valueFactory>
                         <javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory max="2147483391" min="0" />
                       </valueFactory>
@@ -788,7 +789,7 @@
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
                     </Spinner>
-                    <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSModelLoad" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="8">
+                    <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#maxCSSModelLoad" text="Max" GridPane.columnIndex="3" GridPane.rowIndex="9">
                               <GridPane.margin>
                                  <Insets left="2.0" right="2.0" />
                               </GridPane.margin>
@@ -796,7 +797,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#reorderCharacters" text="Reorder Characters" GridPane.rowIndex="9">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#reorderCharacters" text="Reorder Characters" GridPane.rowIndex="10">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -804,7 +805,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#reorderStages" text="Reorder Stages" GridPane.rowIndex="10">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#reorderStages" text="Reorder Stages" GridPane.rowIndex="11">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -812,7 +813,7 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#modifyCostumes" text="Modify Costumes" GridPane.columnIndex="1" GridPane.rowIndex="11">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#modifyCostumes" text="Modify Costumes" GridPane.columnIndex="1" GridPane.rowIndex="12">
                               <font>
                                  <Font size="16.0" />
                               </font>
@@ -820,7 +821,7 @@
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
                            </Button>
-                           <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Additional Character Costumes" GridPane.rowIndex="11">
+                           <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Additional Character Costumes" GridPane.rowIndex="12">
                               <font>
                                  <Font size="16.0" />
                               </font>
@@ -828,7 +829,7 @@
                                  <Insets left="8.0" />
                               </GridPane.margin>
                            </Text>
-                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#modifyEyes" text="Modify Eyes" GridPane.columnIndex="2" GridPane.rowIndex="11">
+                           <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#modifyEyes" text="Modify Eyes" GridPane.columnIndex="2" GridPane.rowIndex="12">
                               <GridPane.margin>
                                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
                               </GridPane.margin>
@@ -836,6 +837,15 @@
                                  <Font size="16.0" />
                               </font>
                            </Button>
+                           <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-id" text="Fix Costume Duplicate Check" GridPane.rowIndex="5">
+                              <font>
+                                 <Font size="16.0" />
+                              </font>
+                              <GridPane.margin>
+                                 <Insets bottom="8.0" left="8.0" top="8.0" />
+                              </GridPane.margin>
+                           </Text>
+                           <CheckBox fx:id="fixCostumeDuplicateCheck" mnemonicParsing="false" onAction="#fixCostumeDuplicateCheck" GridPane.columnIndex="1" GridPane.rowIndex="5" />
                         </children>
                      </GridPane>
                   </children>

--- a/src/test/java/com/github/nicholasmoser/gnt4/ui/DupeCostumeFixTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/ui/DupeCostumeFixTest.java
@@ -1,0 +1,75 @@
+package com.github.nicholasmoser.gnt4.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEdit;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEditBuilder;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqExt;
+import com.github.nicholasmoser.testing.Prereqs;
+import com.github.nicholasmoser.utils.ByteUtils;
+import com.github.nicholasmoser.utils.FileUtils;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class DupeCostumeFixTest {
+
+  private static final String EXT_PARAM_1_NAME = "Fix Costume Duplicate Check (extension_parameters_1)";
+  private static final int EXT_PARAM_1_OFFSET = 0x5798;
+  private static final int EXT_PARAM_1_LENGTH = 0x18;
+  private static final byte[] EXT_PARAM_1_NEW_BYTES = ByteUtils.hexTextToBytes("""
+      3C010000 0000000C 7FFFFF2D
+      3C010000 0000000F 7FFFFF2E
+      3C010000 00000006 7FFFFF24
+      3C010000 00000009 7FFFFF25
+      """);
+
+  @Test
+  public void dupeCostumFixWorks() throws Exception {
+    Path uncompressed = Prereqs.getUncompressedGNT4();
+    Path tempDir = FileUtils.getTempDirectory();
+    Path testFile = tempDir.resolve(UUID.randomUUID().toString());
+
+    Path charSel = uncompressed.resolve("files/maki/char_sel.seq");
+    Files.copy(charSel, testFile);
+    try {
+      // No edits, integrity is valid, code is not enabled
+      List<SeqEdit> edits = SeqExt.getEdits(testFile);
+      assertThat(edits).isEmpty();
+      assertThat(DupeCostumeFix.verifyIntegrity(edits)).isEmpty();
+      assertThat(DupeCostumeFix.isEnabled(edits)).isFalse();
+
+      // Enable the fix, integrity is valid, code is enabled
+      DupeCostumeFix.enable(testFile);
+      edits = SeqExt.getEdits(testFile);
+      assertThat(edits).hasSize(6);
+      assertThat(DupeCostumeFix.verifyIntegrity(edits)).isEmpty();
+      assertThat(DupeCostumeFix.isEnabled(edits)).isTrue();
+
+      // Disable the fix, integrity is valid, code is disabled
+      DupeCostumeFix.disable(testFile);
+      edits = SeqExt.getEdits(testFile);
+      assertThat(edits).isEmpty();
+      assertThat(DupeCostumeFix.verifyIntegrity(edits)).isEmpty();
+      assertThat(DupeCostumeFix.isEnabled(edits)).isFalse();
+
+      // Partially apply the fix, integrity is invalid, code is disabled
+      SeqEdit edit = SeqEditBuilder.getBuilder()
+          .name(EXT_PARAM_1_NAME)
+          .newBytes(EXT_PARAM_1_NEW_BYTES)
+          .seqPath(testFile)
+          .startOffset(EXT_PARAM_1_OFFSET)
+          .endOffset(EXT_PARAM_1_OFFSET + EXT_PARAM_1_LENGTH)
+          .create();
+      SeqExt.addEdit(edit, testFile);
+      edits = SeqExt.getEdits(testFile);
+      assertThat(edits).hasSize(1);
+      assertThat(DupeCostumeFix.verifyIntegrity(edits)).hasSize(5);
+      assertThat(DupeCostumeFix.isEnabled(edits)).isFalse();
+    } finally {
+      Files.deleteIfExists(testFile);
+    }
+  }
+}


### PR DESCRIPTION
The existing code of the game treats costumes 1 and 3 as identical. Same for 2 and 4. It probably does this since the clothes are the same (despite face/hair changing). Also, when the code detects a duplicate costume it goes from costume 1->2, 2->1, 3->4, 4->3.

Both of these behaviors are an issue. Going from 3->4 crashes if there's no costume 4. Also, you can't have costume 1 and 3 fight each other because the game thinks they're duplicates. Same for 2 and 4. I fixed this by writing new code that overwrites the existing behavior. 1 and 3, 2 and 4 are no longer considered duplicates Also, 3 no longer falls back to 4 in case of duplicate, now it goes to 2.

![image](https://user-images.githubusercontent.com/4983605/194730394-68d6da08-914b-44dc-8c49-433fedf01705.png)
