### PR TITLE
Fix model physics costume table branch

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Functions.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Functions.java
@@ -37,127 +37,171 @@ public class Functions {
   private static Map<String, Map<Integer, Function>> getAllFunctions() {
     Map<String, Map<Integer, Function>> allFunctions = new HashMap<>();
 
+    Function costumeModelPhysics = new Function("costume_model_physics",
+        List.of("// Branch table on costume id for model physics, e.g. Ino hair, Temari sash"));
+
     Map<Integer, Function> functions = getChrBaseFunctions(Seqs.ANK_0000);
+    functions.put(0x25004, costumeModelPhysics);
     allFunctions.put(Seqs.ANK_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.BOU_0000);
+    functions.put(0x27ABC, costumeModelPhysics);
     allFunctions.put(Seqs.BOU_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.CHO_0000);
+    functions.put(0x26788, costumeModelPhysics);
     allFunctions.put(Seqs.CHO_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.DOG_0000);
+    functions.put(0x1C018, costumeModelPhysics);
     allFunctions.put(Seqs.DOG_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.GAI_0000);
+    functions.put(0x24204, costumeModelPhysics);
     allFunctions.put(Seqs.GAI_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.GAR_0000);
+    functions.put(0x27FBC, costumeModelPhysics);
     allFunctions.put(Seqs.GAR_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.HAK_0000);
+    functions.put(0x24560, costumeModelPhysics);
     allFunctions.put(Seqs.HAK_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.HI2_0000);
+    functions.put(0x23EC8, costumeModelPhysics);
     allFunctions.put(Seqs.HI2_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.HIN_0000);
+    functions.put(0x255B0, costumeModelPhysics);
     allFunctions.put(Seqs.HIN_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.INO_0000);
+    functions.put(0x265B4, costumeModelPhysics);
     allFunctions.put(Seqs.INO_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.IRU_0000);
+    functions.put(0x22C7C, costumeModelPhysics);
     allFunctions.put(Seqs.IRU_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.ITA_0000);
+    functions.put(0x28D94, costumeModelPhysics);
     allFunctions.put(Seqs.ITA_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.JIR_0000);
+    functions.put(0x26158, costumeModelPhysics);
     allFunctions.put(Seqs.JIR_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KAB_0000);
+    functions.put(0x24C4C, costumeModelPhysics);
     allFunctions.put(Seqs.KAB_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KAK_0000);
+    functions.put(0x31F1C, costumeModelPhysics);
     allFunctions.put(Seqs.KAK_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KAN_0000);
+    functions.put(0x24D84, costumeModelPhysics);
     allFunctions.put(Seqs.KAN_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KAR_0000);
+    functions.put(0x1F948, costumeModelPhysics);
     allFunctions.put(Seqs.KAR_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KIB_0000);
+    functions.put(0x288B4, costumeModelPhysics);
     allFunctions.put(Seqs.KIB_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KID_0000);
+    functions.put(0x263BC, costumeModelPhysics);
     allFunctions.put(Seqs.KID_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KIM_0000);
+    functions.put(0x26B94, costumeModelPhysics);
     allFunctions.put(Seqs.KIM_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.KIS_0000);
+    functions.put(0x24C34, costumeModelPhysics);
     allFunctions.put(Seqs.KIS_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.LOC_0000);
+    functions.put(0x277A8, costumeModelPhysics);
     allFunctions.put(Seqs.LOC_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.MIZ_0000);
+    functions.put(0x22E1C, costumeModelPhysics);
     allFunctions.put(Seqs.MIZ_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.NA9_0000);
+    functions.put(0x24360, costumeModelPhysics);
     allFunctions.put(Seqs.NA9_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.NAR_0000);
+    functions.put(0x2F340, costumeModelPhysics);
     allFunctions.put(Seqs.NAR_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.NEJ_0000);
+    functions.put(0x2563C, costumeModelPhysics);
     allFunctions.put(Seqs.NEJ_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.OBO_0000);
+    functions.put(0x1A088, costumeModelPhysics);
     allFunctions.put(Seqs.OBO_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.ORO_0000);
+    functions.put(0x26920, costumeModelPhysics);
     allFunctions.put(Seqs.ORO_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SA2_0000);
+    functions.put(0x25DF8, costumeModelPhysics);
     allFunctions.put(Seqs.SA2_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SAK_0000);
+    functions.put(0x26940, costumeModelPhysics);
     allFunctions.put(Seqs.SAK_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SAR_0000);
+    functions.put(0x24CE8, costumeModelPhysics);
     allFunctions.put(Seqs.SAR_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SAS_0000);
+    functions.put(0x2908C, costumeModelPhysics);
     allFunctions.put(Seqs.SAS_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SIK_0000);
+    functions.put(0x264DC, costumeModelPhysics);
     allFunctions.put(Seqs.SIK_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SIN_0000);
+    functions.put(0x252E4, costumeModelPhysics);
     allFunctions.put(Seqs.SIN_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.SKO_0000);
+    functions.put(0x259C0, costumeModelPhysics);
     allFunctions.put(Seqs.SKO_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.TA2_0000);
+    functions.put(0x191B8, costumeModelPhysics);
     allFunctions.put(Seqs.TA2_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.TAY_0000);
+    functions.put(0x27D90, costumeModelPhysics);
     allFunctions.put(Seqs.TAY_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.TEM_0000);
+    functions.put(0x29B14, costumeModelPhysics);
     allFunctions.put(Seqs.TEM_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.TEN_0000);
+    functions.put(0x2B108, costumeModelPhysics);
     allFunctions.put(Seqs.TEN_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.TSU_0000);
+    functions.put(0x255A4, costumeModelPhysics);
     allFunctions.put(Seqs.TSU_0000, functions);
 
     functions = getChrBaseFunctions(Seqs.ZAB_0000);
+    functions.put(0x22EFC, costumeModelPhysics);
     allFunctions.put(Seqs.ZAB_0000, functions);
 
     functions = new HashMap<>();

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEdit.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEdit.java
@@ -259,7 +259,6 @@ public class SeqEdit {
               newOffsets.add(targetOffset);
             }
           }
-          System.out.println(newOffsets);
           branchTable.setOffsets(newOffsets);
         } else if (op instanceof BranchTableLink branchTableLink) {
           List<Integer> newOffsets = new LinkedList<>();
@@ -270,7 +269,6 @@ public class SeqEdit {
               newOffsets.add(targetOffset);
             }
           }
-          System.out.println(newOffsets);
           branchTableLink.setOffsets(newOffsets);
         }
         baos.write(op.getBytes(position, size));
@@ -311,7 +309,6 @@ public class SeqEdit {
               newOffsets.add(targetOffset);
             }
           }
-          System.out.println(newOffsets);
           branchTable.setOffsets(newOffsets);
         } else if (op instanceof BranchTableLink branchTableLink) {
           List<Integer> newOffsets = new LinkedList<>();
@@ -324,7 +321,6 @@ public class SeqEdit {
               newOffsets.add(targetOffset);
             }
           }
-          System.out.println(newOffsets);
           branchTableLink.setOffsets(newOffsets);
         }
         baos.write(op.getBytes(position, size));

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
@@ -68,7 +68,7 @@ public class CostumeBranchTableFix {
   private static final int ZAB_TABLE_OFFSET = 0x22F04;
 
   // Characters with 4 costumes in vanilla
-  private static final int HAK_TABLE_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
+  private static final int HAK_TABLE_OFFSET = 0x24568; // TODO: Implement Haku, currently complicated because of the mask
   private static final int HAK_BRANCH1_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
   private static final int HAK_BRANCH2_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
   private static final int INO_TABLE_OFFSET = 0x265BC;
@@ -82,7 +82,7 @@ public class CostumeBranchTableFix {
   private static final int TEM_SHORT_SASH_OFFSET = 0x29B84;
 
   // Sakura's branch table has 5 indices and all with the same offset, no need to implement
-  private static final int SAK_TABLE_OFFSET = -1;
+  private static final int SAK_TABLE_OFFSET = 0x29094;
 
   private static final String CODE_NAME = "Costume Branch Table Fix";
   private static final byte[] BRANCH_TABLE_4_BRANCHES = ByteUtils.hexTextToBytes(

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
@@ -1,0 +1,327 @@
+package com.github.nicholasmoser.gnt4.ui;
+
+import com.github.nicholasmoser.gnt4.GNT4Characters;
+import com.github.nicholasmoser.gnt4.seq.Seqs;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEdit;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqEditBuilder;
+import com.github.nicholasmoser.gnt4.seq.ext.SeqExt;
+import com.github.nicholasmoser.utils.ByteUtils;
+import com.google.common.primitives.Bytes;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonBar.ButtonData;
+import javafx.scene.control.ButtonType;
+
+/**
+ * In the character 0000.seq file, there is a branch table where for each costume, it is believed
+ * that gravity or extra physics are added to specific bones on a model. Examples include the
+ * gravity for Kisame's sword wrappings and Temari's sash. This Java class will modify the branch
+ * table to use a different offset for costumes 3 and 4. Most characters are simple, and will use
+ * the same offset for all four costumes. Other characters require the user to decide which costume
+ * to apply where.
+ */
+public class CostumeBranchTableFix {
+
+  // Character with 2 costumes in vanilla
+  private static final int ANK_TABLE_OFFSET = 0x2500C;
+  private static final int BOU_TABLE_OFFSET = 0x27AC4;
+  private static final int CHO_TABLE_OFFSET = 0x26790;
+  private static final int DOG_TABLE_OFFSET = 0x1C020; // TODO: Dog has existing logic for costumes 3 and 4
+  private static final int GAI_TABLE_OFFSET = 0x2420C;
+  private static final int GAR_TABLE_OFFSET = 0x27FC4;
+  private static final int HI2_TABLE_OFFSET = 0x23ED0;
+  private static final int HIN_TABLE_OFFSET = 0x255B8;
+  private static final int IRU_TABLE_OFFSET = 0x22C84;
+  private static final int ITA_TABLE_OFFSET = 0x28D9C;
+  private static final int JIR_TABLE_OFFSET = 0x26160;
+  private static final int KAB_TABLE_OFFSET = 0x24C54;
+  private static final int KAK_TABLE_OFFSET = 0x31F24;
+  private static final int KAN_TABLE_OFFSET = 0x24D8C;
+  private static final int KAR_TABLE_OFFSET = 0x1F950; // TODO: Karasu has existing logic for costumes 3 and 4
+  private static final int KIB_TABLE_OFFSET = 0x288BC;
+  private static final int KID_TABLE_OFFSET = 0x263C4; // TODO: Kidomaru has existing logic for costumes 3 and 4
+  private static final int KIM_TABLE_OFFSET = 0x26B9C;
+  private static final int KIS_TABLE_OFFSET = 0x24C3C;
+  private static final int LOC_TABLE_OFFSET = 0x277B0;
+  private static final int MIZ_TABLE_OFFSET = 0x22E24;
+  private static final int NA9_TABLE_OFFSET = 0x24368; // TODO: OTK has existing logic for costumes 3 and 4
+  private static final int NAR_TABLE_OFFSET = 0x2F348;
+  private static final int NEJ_TABLE_OFFSET = 0x25644;
+  private static final int OBO_TABLE_OFFSET = 0x1A090;
+  private static final int ORO_TABLE_OFFSET = 0x26928;
+  private static final int SA2_TABLE_OFFSET = 0x25E00;
+  private static final int SAR_TABLE_OFFSET = 0x24CF0;
+  private static final int SIK_TABLE_OFFSET = 0x264E4;
+  private static final int SIN_TABLE_OFFSET = 0x252EC;
+  private static final int SKO_TABLE_OFFSET = 0x259C8; // TODO: Sakon has existing logic for costumes 3 and 4
+  private static final int TA2_TABLE_OFFSET = 0x191C0;
+  private static final int TAY_TABLE_OFFSET = 0x27D98;
+  private static final int TEN_TABLE_OFFSET = 0x2B110;
+  private static final int TSU_TABLE_OFFSET = 0x255AC;
+  private static final int ZAB_TABLE_OFFSET = 0x22F04;
+
+  // Characters with 4 costumes in vanilla
+  private static final int HAK_TABLE_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
+  private static final int HAK_BRANCH1_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
+  private static final int HAK_BRANCH2_OFFSET = -1; // TODO: Implement Haku, currently complicated because of the mask
+  private static final int INO_TABLE_OFFSET = 0x265BC;
+  private static final int INO_SHORT_HAIR_OFFSET = 0x265D4;
+  private static final int INO_LONG_HAIR_OFFSET = 0x267CC;
+  private static final int SAS_TABLE_OFFSET = -1; // Sasuke has the same code for all costumes, no need to implement
+
+  // Temari has 2 costumes but separate logic for each
+  private static final int TEM_TABLE_OFFSET = 0x29B1C;
+  private static final int TEM_LONG_SASH_OFFSET = 0x29B34;
+  private static final int TEM_SHORT_SASH_OFFSET = 0x29B84;
+
+  // Sakura's branch table has 5 indices and all with the same offset, no need to implement
+  private static final int SAK_TABLE_OFFSET = -1;
+
+  private static final String CODE_NAME = "Costume Branch Table Fix";
+  private static final byte[] BRANCH_TABLE_4_BRANCHES = ByteUtils.hexTextToBytes(
+      "01500013 00000004");
+
+  /**
+   * Implement a simple case of the costume branch table fix. This involves writing a new branch
+   * table where all four branches will be the same offset (the code immediately after the branch
+   * table).
+   *
+   * @param tableOffset The offset in the seq file to the branch table.
+   * @param seqPath     The path to the character 0000.seq file.
+   */
+  private static void enableSimpleCase(int tableOffset, Path seqPath) throws IOException {
+    for (SeqEdit edit : SeqExt.getEdits(seqPath)) {
+      if (edit.getName().equals(CODE_NAME)) {
+        return; // Code is already applied, do nothing
+      }
+    }
+    int codeOffset = tableOffset + 0x18;
+    byte[] codeOffsetBytes = ByteUtils.fromInt32(codeOffset);
+    byte[] bytes = Bytes.concat(BRANCH_TABLE_4_BRANCHES, codeOffsetBytes, codeOffsetBytes,
+        codeOffsetBytes, codeOffsetBytes);
+    SeqEdit edit = SeqEditBuilder.getBuilder()
+        .name(CODE_NAME)
+        .newBytes(bytes)
+        .seqPath(seqPath)
+        .startOffset(tableOffset)
+        .endOffset(codeOffset)
+        .create();
+    SeqExt.addEdit(edit, seqPath);
+  }
+
+  private static void enableTemari(Path uncompressedDir) throws IOException {
+    Path seqPath = uncompressedDir.resolve(Seqs.TEM_0000);
+    for (SeqEdit edit : SeqExt.getEdits(seqPath)) {
+      if (edit.getName().equals(CODE_NAME)) {
+        SeqExt.removeEdit(edit, seqPath); // Remove existing edit
+      }
+    }
+
+    // Get the branch for costume 3
+    ButtonType longSash = new ButtonType("Long Sash", ButtonData.OK_DONE);
+    ButtonType shortSash = new ButtonType("Short Sash", ButtonData.OK_DONE);
+    Alert alert = new Alert(AlertType.WARNING,
+        """
+            Please select whether Temari's costume 3 will use her model with the long sash
+            (costume 1) or the short sash (costume 2). This is necessary even if Temari costume 3
+            is not being used.
+            """,
+        longSash,
+        shortSash);
+    alert.setTitle("Temari Costume 3 Fix");
+    Optional<ButtonType> result = alert.showAndWait();
+    boolean usingLongSash = result.orElse(longSash) == longSash;
+    byte[] costume3 = ByteUtils.fromInt32(
+        usingLongSash ? TEM_LONG_SASH_OFFSET : TEM_SHORT_SASH_OFFSET);
+
+    // Get the branch for costume 4
+    longSash = new ButtonType("Long Sash", ButtonData.OK_DONE);
+    shortSash = new ButtonType("Short Sash", ButtonData.OK_DONE);
+    alert = new Alert(AlertType.WARNING,
+        """
+            Please select whether Temari's costume 4 will use her model with the long sash
+            (costume 1) or the short sash (costume 2). This is necessary even if Temari costume 4
+            is not being used.
+            """,
+        longSash,
+        shortSash);
+    alert.setTitle("Temari Costume 4 Fix");
+    result = alert.showAndWait();
+    usingLongSash = result.orElse(longSash) == longSash;
+    byte[] costume4 = ByteUtils.fromInt32(
+        usingLongSash ? TEM_LONG_SASH_OFFSET : TEM_SHORT_SASH_OFFSET);
+
+    // Write the code
+    int codeOffset = TEM_TABLE_OFFSET + 0x18;
+    byte[] longSashBytes = ByteUtils.fromInt32(TEM_LONG_SASH_OFFSET);
+    byte[] shortSashBytes = ByteUtils.fromInt32(TEM_SHORT_SASH_OFFSET);
+    byte[] bytes = Bytes.concat(BRANCH_TABLE_4_BRANCHES, longSashBytes, shortSashBytes,
+        costume3, costume4);
+    SeqEdit edit = SeqEditBuilder.getBuilder()
+        .name(CODE_NAME)
+        .newBytes(bytes)
+        .seqPath(seqPath)
+        .startOffset(TEM_TABLE_OFFSET)
+        .endOffset(codeOffset)
+        .create();
+    SeqExt.addEdit(edit, seqPath);
+  }
+
+  private static void enableIno(Path uncompressedDir) throws IOException {
+    Path seqPath = uncompressedDir.resolve(Seqs.INO_0000);
+    for (SeqEdit edit : SeqExt.getEdits(seqPath)) {
+      if (edit.getName().equals(CODE_NAME)) {
+        SeqExt.removeEdit(edit, seqPath); // Remove existing edit
+      }
+    }
+
+    // Get the branch for costume 3
+    ButtonType longSash = new ButtonType("Short Hair", ButtonData.OK_DONE);
+    ButtonType shortSash = new ButtonType("Long Hair", ButtonData.OK_DONE);
+    Alert alert = new Alert(AlertType.WARNING,
+        """
+            Please select whether Ino's costume 3 will use her model with the short hair
+            (costume 1) or the long hair (costume 3). This is necessary even if Ino costume 3
+            is not being used.
+            """,
+        longSash,
+        shortSash);
+    alert.setTitle("Ino Costume 3 Fix");
+    Optional<ButtonType> result = alert.showAndWait();
+    boolean usingLongSash = result.orElse(longSash) == longSash;
+    byte[] costume3 = ByteUtils.fromInt32(
+        usingLongSash ? INO_SHORT_HAIR_OFFSET : INO_LONG_HAIR_OFFSET);
+
+    // Get the branch for costume 4
+    longSash = new ButtonType("Short Hair", ButtonData.OK_DONE);
+    shortSash = new ButtonType("Long Hair", ButtonData.OK_DONE);
+    alert = new Alert(AlertType.WARNING,
+        """
+            Please select whether Ino's costume 4 will use her model with the short hair
+            (costume 1) or the long hair (costume 3). This is necessary even if Ino costume 4
+            is not being used.
+            """,
+        longSash,
+        shortSash);
+    alert.setTitle("Ino Costume 4 Fix");
+    result = alert.showAndWait();
+    usingLongSash = result.orElse(longSash) == longSash;
+    byte[] costume4 = ByteUtils.fromInt32(
+        usingLongSash ? INO_SHORT_HAIR_OFFSET : INO_LONG_HAIR_OFFSET);
+
+    // Write the code
+    int codeOffset = INO_TABLE_OFFSET + 0x18;
+    byte[] shortHairBytes = ByteUtils.fromInt32(INO_SHORT_HAIR_OFFSET);
+    byte[] bytes = Bytes.concat(BRANCH_TABLE_4_BRANCHES, shortHairBytes, shortHairBytes,
+        costume3, costume4);
+    SeqEdit edit = SeqEditBuilder.getBuilder()
+        .name(CODE_NAME)
+        .newBytes(bytes)
+        .seqPath(seqPath)
+        .startOffset(INO_TABLE_OFFSET)
+        .endOffset(codeOffset)
+        .create();
+    SeqExt.addEdit(edit, seqPath);
+  }
+
+  private static void enableHaku(Path uncompressedDir) throws IOException {
+    throw new IOException("Unsupported character for CostumeBranchTableFix: Haku");
+  }
+
+  /**
+   * Enables the fix on all character SEQ files
+   *
+   * @param uncompressedDir The path to the uncompressed directory.
+   * @throws IOException If an I/O error occurs.
+   */
+  public static void enable(Path uncompressedDir, List<String> chrs) throws IOException {
+    for (String chr : chrs) {
+      switch (chr) {
+        // First try and handle the easy characters, then handle the more complex characters
+        case GNT4Characters.ANKO -> enableSimpleCase(ANK_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.ANK_0000));
+        case GNT4Characters.JIROBO -> enableSimpleCase(BOU_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.BOU_0000));
+        case GNT4Characters.CHOJI -> enableSimpleCase(CHO_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.CHO_0000));
+        case GNT4Characters.AKAMARU -> enableSimpleCase(DOG_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.DOG_0000));
+        case GNT4Characters.MIGHT_GUY -> enableSimpleCase(GAI_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.GAI_0000));
+        case GNT4Characters.GAARA -> enableSimpleCase(GAR_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.GAR_0000));
+        case GNT4Characters.HINATA_AWAKENED -> enableSimpleCase(HI2_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.HI2_0000));
+        case GNT4Characters.HINATA -> enableSimpleCase(HIN_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.HIN_0000));
+        case GNT4Characters.IRUKA -> enableSimpleCase(IRU_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.IRU_0000));
+        case GNT4Characters.ITACHI -> enableSimpleCase(ITA_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.ITA_0000));
+        case GNT4Characters.JIRAIYA -> enableSimpleCase(JIR_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.JIR_0000));
+        case GNT4Characters.KABUTO -> enableSimpleCase(KAB_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KAB_0000));
+        case GNT4Characters.KAKASHI -> enableSimpleCase(KAK_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KAK_0000));
+        case GNT4Characters.KANKURO -> enableSimpleCase(KAN_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KAN_0000));
+        case GNT4Characters.KARASU -> enableSimpleCase(KAR_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KAR_0000));
+        case GNT4Characters.KIBA -> enableSimpleCase(KIB_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KIB_0000));
+        case GNT4Characters.KIDOMARU -> enableSimpleCase(KID_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KID_0000));
+        case GNT4Characters.KIMIMARO -> enableSimpleCase(KIM_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KIM_0000));
+        case GNT4Characters.KISAME -> enableSimpleCase(KIS_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.KIS_0000));
+        case GNT4Characters.LEE -> enableSimpleCase(LOC_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.LOC_0000));
+        case GNT4Characters.MIZUKI -> enableSimpleCase(MIZ_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.MIZ_0000));
+        case GNT4Characters.NARUTO_OTK -> enableSimpleCase(NA9_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.NA9_0000));
+        case GNT4Characters.NARUTO -> enableSimpleCase(NAR_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.NAR_0000));
+        case GNT4Characters.NEJI -> enableSimpleCase(NEJ_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.NEJ_0000));
+        case GNT4Characters.OBORO -> enableSimpleCase(OBO_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.OBO_0000));
+        case GNT4Characters.OROCHIMARU -> enableSimpleCase(ORO_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.ORO_0000));
+        case GNT4Characters.SASUKE_CS2 -> enableSimpleCase(SA2_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.SA2_0000));
+        case GNT4Characters.SARUTOBI -> enableSimpleCase(SAR_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.SAR_0000));
+        case GNT4Characters.SHIKAMARU -> enableSimpleCase(SIK_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.SIK_0000));
+        case GNT4Characters.SHINO -> enableSimpleCase(SIN_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.SIN_0000));
+        case GNT4Characters.SAKON -> enableSimpleCase(SKO_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.SKO_0000));
+        case GNT4Characters.TAYUYA_DOKI -> enableSimpleCase(TA2_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.TA2_0000));
+        case GNT4Characters.TAYUYA -> enableSimpleCase(TAY_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.TAY_0000));
+        case GNT4Characters.TENTEN -> enableSimpleCase(TEN_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.TEN_0000));
+        case GNT4Characters.TSUNADE -> enableSimpleCase(TSU_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.TSU_0000));
+        case GNT4Characters.ZABUZA -> enableSimpleCase(ZAB_TABLE_OFFSET,
+            uncompressedDir.resolve(Seqs.ZAB_0000));
+        // Handle special cases
+        case GNT4Characters.HAKU -> enableHaku(uncompressedDir);
+        case GNT4Characters.INO -> enableIno(uncompressedDir);
+        case GNT4Characters.TEMARI -> enableTemari(uncompressedDir);
+        case GNT4Characters.SASUKE, GNT4Characters.SAKURA -> {
+        } // Do nothing, no changes necessary
+        default -> throw new IOException("Unsupported character for CostumeBranchTableFix: " + chr);
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeBranchTableFix.java
@@ -9,8 +9,9 @@ import com.github.nicholasmoser.utils.ByteUtils;
 import com.google.common.primitives.Bytes;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.logging.Logger;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonBar.ButtonData;
@@ -25,6 +26,8 @@ import javafx.scene.control.ButtonType;
  * to apply where.
  */
 public class CostumeBranchTableFix {
+
+  private static final Logger LOGGER = Logger.getLogger(CostumeBranchTableFix.class.getName());
 
   // Character with 2 costumes in vanilla
   private static final int ANK_TABLE_OFFSET = 0x2500C;
@@ -229,7 +232,8 @@ public class CostumeBranchTableFix {
   }
 
   private static void enableHaku(Path uncompressedDir) throws IOException {
-    throw new IOException("Unsupported character for CostumeBranchTableFix: Haku");
+    // TODO: Implement Haku costume extension
+    LOGGER.info("Unsupported character for CostumeBranchTableFix: Haku");
   }
 
   /**
@@ -238,7 +242,7 @@ public class CostumeBranchTableFix {
    * @param uncompressedDir The path to the uncompressed directory.
    * @throws IOException If an I/O error occurs.
    */
-  public static void enable(Path uncompressedDir, List<String> chrs) throws IOException {
+  public static void enable(Path uncompressedDir, Collection<String> chrs) throws IOException {
     for (String chr : chrs) {
       switch (chr) {
         // First try and handle the easy characters, then handle the more complex characters

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
@@ -8,6 +8,7 @@ import com.github.nicholasmoser.gnt4.seq.ext.SeqExt;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -74,6 +75,8 @@ public class CostumeController {
   public void save() {
     List<String> costumes3 = costume3.getItems();
     List<String> costumes4 = costume4.getItems();
+    Set<String> allCostumes = new HashSet<>(costumes3);
+    allCostumes.addAll(costumes4);
     try {
       verifyIntegrity(costumes3, costumes4);
       checkDupeCostumeFix(charSel);
@@ -85,6 +88,7 @@ public class CostumeController {
         CostumeExtender.allowAlternateCostumeModels(charSel, charSel4);
       }
       hasCodes = true;
+      CostumeBranchTableFix.enable(uncompressedDirectory, allCostumes);
       CostumeExtender.writeCostumeThreeCodes(charSel, charSel4, costumes3);
       CostumeExtender.writeCostumeFourCodes(charSel, charSel4, costumes4);
     } catch (IOException e) {

--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/CostumeController.java
@@ -77,6 +77,13 @@ public class CostumeController {
     List<String> costumes4 = costume4.getItems();
     Set<String> allCostumes = new HashSet<>(costumes3);
     allCostumes.addAll(costumes4);
+    if (allCostumes.contains(GNT4Characters.KANKURO)) {
+      allCostumes.add(GNT4Characters.KARASU);
+    } else if (allCostumes.contains(GNT4Characters.TAYUYA)) {
+      allCostumes.add(GNT4Characters.TAYUYA_DOKI);
+    } else if (allCostumes.contains(GNT4Characters.KIBA)) {
+      allCostumes.add(GNT4Characters.AKAMARU);
+    }
     try {
       verifyIntegrity(costumes3, costumes4);
       checkDupeCostumeFix(charSel);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -15,7 +15,7 @@ public class SeqKingTest {
   private static final boolean COMPARE_MODE = false;
   private static final boolean VERBOSE = false;
   private static final boolean PERMISSIVE = false;
-  private static final boolean DELETE_FILE = true;
+  private static final boolean DELETE_FILE = false;
 
   @Test
   public void parseTitle() throws Exception {


### PR DESCRIPTION
In each SEQ file is a branch table for the costume id. Each branch contains specific physics for that model, such as Temari's sash or the paper bandages on Kisame's sword. Most characters have no physics set for costumes 3 and 4, so physics will be broken for many characters. In cases like Ino, the costume may crash completely if the physics code reference parts of the model that do not exist (such as using a short hair Ino on costume 3 and 4, which expects long hair).

This PR simply writes a SEQ edit to fix the branch table. Easy cases are handled automatically, whereas cases like Ino will ask the user how they want to handle it.