### PR TITLE
Fix corrupted databases and display SEQ editor values in hex

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -1532,6 +1532,16 @@ public class MenuController {
   private void syncRefresh() throws IOException {
     LOGGER.log(Level.INFO, "Refreshing workspace.");
     List<WorkspaceFile> allFiles = workspace.getAllFiles();
+    if (allFiles.isEmpty()) {
+      String msg = """
+          The workspace database is missing every file entry. This likely means that the entries
+          were removed from the database but were not added back after building an ISO. The safest
+          option at this point is to rebuild the database, which means any changes since the last
+          ISO build will not be detected by GNTool. Rebuilding the database...
+          """;
+      LOGGER.log(Level.SEVERE, msg);
+      rebuildWorkspace();
+    }
     // The below two calls can be slow the first time they are called since it needs to check
     // if each file in the workspace exists. I'm not sure if this can be avoided.
     refreshMissingFiles(allFiles);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEditor.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/ext/SeqEditor.java
@@ -177,8 +177,8 @@ public class SeqEditor {
     }
     List<Opcode> newCodes = seqEdit.getNewCodes();
     nameTextArea.setText(editName);
-    offsetTextField.setText(Integer.toString(seqEdit.getOffset()));
-    hijackedBytesLengthTextField.setText(Integer.toString(oldBytes.length));
+    offsetTextField.setText(String.format("0x%X", seqEdit.getOffset()));
+    hijackedBytesLengthTextField.setText(String.format("0x%X", oldBytes.length));
     hijackedBytesTextArea.setText(sb.toString());
     Pair<String,String> opcodesStrings = getOpcodesStrings(newCodes, seqEdit.getSize());
     newBytesTextArea.setText(opcodesStrings.getKey());


### PR DESCRIPTION
Fix two issues:

- It is possible in some circumstances for the file entries to be removed from the sqlite database but not added back after building an ISO. After this happens, changes to files will no longer be tracked since it thinks no files exist in the workspace. I've added a fix to the refresh method to check for this and rebuild the database if it is detected.
- Display offset and hijacked byte length in hex since hex is most often used for each value