### PR TITLE
Add fix for parsing code 'Allow Additional Eye Textures' with no codes.json

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/ui/EyeExtender.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/ui/EyeExtender.java
@@ -97,15 +97,15 @@ public class EyeExtender {
   public static final long MAIN_TARGET_ADDR = 0x800ab634L;
   public static final long NOP1_TARGET_ADDR = 0x800ab628L;
   public static final long NOP2_TARGET_ADDR = 0x800ab630L;
-  private static final byte[] NOP = ByteUtils.hexStringToBytes("60000000");
-  private static final byte[] END = ByteUtils.hexStringToBytes("00000000");
-  private static final byte[] CMPWI_COSTUME_2 = ByteUtils.hexStringToBytes("2C070001");
-  private static final byte[] CMPWI_COSTUME_3 = ByteUtils.hexStringToBytes("2C070002");
-  private static final byte[] CMPWI_COSTUME_4 = ByteUtils.hexStringToBytes("2C070003");
-  private static final byte[] LI_R7_0 = ByteUtils.hexStringToBytes("38E00000");
-  private static final int COSTUME_2_OFFSET = 0xC;
-  private static final int COSTUME_3_OFFSET = 0x14;
-  private static final int COSTUME_4_OFFSET = 0x1C;
+  public static final byte[] NOP = ByteUtils.hexStringToBytes("60000000");
+  public static final byte[] END = ByteUtils.hexStringToBytes("00000000");
+  public static final byte[] CMPWI_COSTUME_2 = ByteUtils.hexStringToBytes("2C070001");
+  public static final byte[] CMPWI_COSTUME_3 = ByteUtils.hexStringToBytes("2C070002");
+  public static final byte[] CMPWI_COSTUME_4 = ByteUtils.hexStringToBytes("2C070003");
+  public static final byte[] LI_R7_0 = ByteUtils.hexStringToBytes("38E00000");
+  public static final int COSTUME_2_OFFSET = 0xC;
+  public static final int COSTUME_3_OFFSET = 0x14;
+  public static final int COSTUME_4_OFFSET = 0x1C;
 
   /**
    * <code>


### PR DESCRIPTION
When creating an workspace from an ISO using the code "Allow Additional Eye Textures", it would error when trying to create the codes.json file. This hack adds a parser for this code, which is extra difficult since it is a dynamic code.

This PR will be followed by a PR that will force codes.json to always be included in the ISO, so that no more hacks like this need to be done.