### PR TITLE
Force bundle codes.json and refresh on build

### DIFF
--- a/src/main/java/com/github/nicholasmoser/FPKPacker.java
+++ b/src/main/java/com/github/nicholasmoser/FPKPacker.java
@@ -68,7 +68,7 @@ public class FPKPacker {
    * @param parallel     If the repacking should attempt to be done in parallel.
    * @throws IOException If there is an I/O issue repacking or moving the files.
    */
-  public void pack(List<String> changedFiles, boolean parallel) throws IOException {
+  public void pack(Collection<String> changedFiles, boolean parallel) throws IOException {
     // Get data needed to repack
     Set<String> changedFPKFiles = new HashSet<>();
     Set<String> changedNonFPKFiles = new HashSet<>();

--- a/src/main/java/com/github/nicholasmoser/Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/Workspace.java
@@ -95,4 +95,10 @@ public interface Workspace {
    * @return The FPK options for this workspace.
    */
   FPKOptions getFPKOptions();
+
+  /**
+   * @return If the workspace is currently saving the state of dol codes.
+   * @throws IOException If any I/O exception occurs.
+   */
+  boolean isSavingCodeState() throws IOException;
 }

--- a/src/main/java/com/github/nicholasmoser/gecko/GeckoCodeJSON.java
+++ b/src/main/java/com/github/nicholasmoser/gecko/GeckoCodeJSON.java
@@ -19,8 +19,9 @@ import org.json.JSONTokener;
 public class GeckoCodeJSON {
 
   // The path to codes.json file when it is bundled with the ISO
-  public static final String PACKED_CODE_FILE_PATH = "extra/codes.json";
-  public static final String CODE_FILE = "codes.json";
+  public static final String CODE_FILE_PATH = "files/extra/codes.json";
+  public static final String CODE_FILE = "extra/codes.json";
+  public static final String LEGACY_CODE_FILE = "codes.json";
 
   /**
    * Writes a list of GeckoCodeGroup objects to a file path.

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
@@ -155,6 +155,11 @@ public class GNT4Workspace implements Workspace {
     return options;
   }
 
+  @Override
+  public boolean isSavingCodeState() throws IOException {
+    return state.isSavingCodeState();
+  }
+
   /**
    * Inserts GNTFiles into the workspace state.
    *

--- a/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/GNT4Workspace.java
@@ -3,6 +3,7 @@ package com.github.nicholasmoser.gnt4;
 import com.github.nicholasmoser.GNTFileProtos.GNTFiles;
 import com.github.nicholasmoser.Workspace;
 import com.github.nicholasmoser.fpk.FPKOptions;
+import com.github.nicholasmoser.gecko.GeckoCodeJSON;
 import com.github.nicholasmoser.utils.CRC32;
 import com.github.nicholasmoser.utils.FPKUtils;
 import com.github.nicholasmoser.workspace.SQLiteWorkspaceState;
@@ -157,7 +158,7 @@ public class GNT4Workspace implements Workspace {
 
   @Override
   public boolean isSavingCodeState() throws IOException {
-    return state.isSavingCodeState();
+    return state.fileExists(GeckoCodeJSON.CODE_FILE_PATH);
   }
 
   /**

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -67,7 +67,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
-import javafx.event.ActionEvent;
 import javafx.event.EventTarget;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -792,18 +791,20 @@ public class MenuController {
    */
   @FXML
   protected void build() {
-    // Force refresh
-    // TODO: Changed files list is updated on FX Application Thread which is slower than this code runs, resulting in not all changed files being included
+    Set<String> currentChangedFiles;
+    Set<String> missingFiles;
     try {
-      syncRefresh();
+      List<WorkspaceFile> files = workspace.getAllFiles();
+      currentChangedFiles = workspace.getChangedFiles(files);
+      missingFiles = workspace.getMissingFiles(files);
     } catch (IOException e) {
-      LOGGER.log(Level.SEVERE, "Error Refreshing Workspace", e);
-      Message.error("Error Refreshing Workspace", e.getMessage());
+      LOGGER.log(Level.SEVERE, "Error Refreshing", e);
+      Message.error("Error Refreshing", e.getMessage());
       return;
     }
 
     // Prevent build if files are missing
-    if (!missingFiles.getItems().isEmpty()) {
+    if (!missingFiles.isEmpty()) {
       String message = "You cannot build the ISO while files are missing.\n";
       message += "Allow GNTool to replace these missing files with 1 KB filler files?";
       boolean yes = Message.warnConfirmation("Missing Files", message);
@@ -824,9 +825,25 @@ public class MenuController {
       }
     }
 
+    // Warn user if codes.json is not being saved
+    try {
+      if (Files.exists(getCodesFile()) && !workspace.isSavingCodeState()) {
+        String msg = "Do you wish to save the state of your codes? If you choose no, new workspaces may fail to generate from your ISO.";
+        if (Message.warnConfirmation("Save Codes State", msg)) {
+          String filePath = "files/extra/codes.json";
+          workspace.addFile(new WorkspaceFile(filePath, 0, 0, null, false));
+          currentChangedFiles.add(filePath);
+        }
+      }
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "Error Checking if Saving Code State", e);
+      Message.error("Error Checking if Saving Code State", e.getMessage());
+      return;
+    }
+
     // Warn user if no files have changed
     final boolean repack;
-    if (changedFiles.getItems().isEmpty()) {
+    if (currentChangedFiles.isEmpty()) {
       String message =
           "There are no changed files in your workspace. Do you still wish to build an ISO?";
       boolean choice = Message.warnConfirmation("No Changed Files", message);
@@ -853,7 +870,7 @@ public class MenuController {
           if (repack) {
             updateMessage("Repacking FPKs...");
             FPKPacker fpkPacker = new FPKPacker(workspace);
-            fpkPacker.pack(changedFiles.getItems(), parallelBuild.isSelected());
+            fpkPacker.pack(currentChangedFiles, parallelBuild.isSelected());
           }
           updateMessage("Building ISO...");
           GameCubeISO.importFiles(compressedDirectory, isoResponse.get(),
@@ -1500,6 +1517,7 @@ public class MenuController {
     this.uncompressedFiles = uncompressedDirectory.resolve("files");
     this.dolPath = uncompressedDirectory.resolve(DOL);
     this.codes = new GNT4Codes(uncompressedDirectory);
+    Files.createDirectories(uncompressedFiles.resolve("extra"));
     musyxSamFile.getItems().setAll(GNT4Audio.SOUND_EFFECTS);
     musyxSamFile.getSelectionModel().selectFirst();
     txg2tplTexture.getItems().setAll(GNT4Graphics.TEXTURES);
@@ -1654,7 +1672,7 @@ public class MenuController {
           if (Message.warnConfirmation("Need to Move Codes", msg)) {
             if (!Files.isRegularFile(codeFile)) {
               // We need the code file to do the conversion, create a code file with the old code cave
-              if (!DolHijack.handleActiveCodesButNoCodeFile(dolPath, CodeCave.RECORDING)) {
+              if (!DolHijack.handleActiveCodesButNoCodeFile(dolPath, CodeCave.RECORDING, codeFile)) {
                 throw new IOException("Recording code is modified, but unable to get code file.");
               }
             }
@@ -1671,7 +1689,7 @@ public class MenuController {
           for (GeckoCodeGroup codeGroup : codeGroups) {
             addedCodes.getItems().add(codeGroup.getName());
           }
-        } else if (DolHijack.handleActiveCodesButNoCodeFile(dolPath, CodeCave.EXI2)) {
+        } else if (DolHijack.handleActiveCodesButNoCodeFile(dolPath, CodeCave.EXI2, codeFile)) {
           // This ISO has injected codes but no associated JSON code file. The previous method
           // call successfully created one, so now let's parse it.
           codeGroups = GeckoCodeJSON.parseFile(codeFile);
@@ -2023,11 +2041,14 @@ public class MenuController {
   /**
    * @return The codes.json path, preferring uncompressed/files/codes.json
    */
-  private Path getCodesFile() {
+  private Path getCodesFile() throws IOException {
+    // For passivity, handle a codes.json in the main workspace directory
+    Path oldCodePath = workspaceDirectory.resolve(GeckoCodeJSON.CODE_FILE);
     Path codePath = uncompressedFiles.resolve(GeckoCodeJSON.PACKED_CODE_FILE_PATH);
-    if (Files.exists(codePath)) {
-      return codePath;
+    if (Files.exists(oldCodePath)) {
+      Files.createDirectories(codePath.getParent());
+      Files.move(oldCodePath, codePath);
     }
-    return workspaceDirectory.resolve(GeckoCodeJSON.CODE_FILE);
+    return codePath;
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/MenuController.java
@@ -792,19 +792,19 @@ public class MenuController {
   @FXML
   protected void build() {
     Set<String> currentChangedFiles;
-    Set<String> missingFiles;
+    Set<String> currentMissingFiles;
     try {
       List<WorkspaceFile> files = workspace.getAllFiles();
       currentChangedFiles = workspace.getChangedFiles(files);
-      missingFiles = workspace.getMissingFiles(files);
+      currentMissingFiles = workspace.getMissingFiles(files);
     } catch (IOException e) {
-      LOGGER.log(Level.SEVERE, "Error Refreshing", e);
-      Message.error("Error Refreshing", e.getMessage());
+      LOGGER.log(Level.SEVERE, "Error Refreshing Workspace", e);
+      Message.error("Error Refreshing Workspace", e.getMessage());
       return;
     }
 
     // Prevent build if files are missing
-    if (!missingFiles.isEmpty()) {
+    if (!currentMissingFiles.isEmpty()) {
       String message = "You cannot build the ISO while files are missing.\n";
       message += "Allow GNTool to replace these missing files with 1 KB filler files?";
       boolean yes = Message.warnConfirmation("Missing Files", message);
@@ -830,7 +830,7 @@ public class MenuController {
       if (Files.exists(getCodesFile()) && !workspace.isSavingCodeState()) {
         String msg = "Do you wish to save the state of your codes? If you choose no, new workspaces may fail to generate from your ISO.";
         if (Message.warnConfirmation("Save Codes State", msg)) {
-          String filePath = "files/extra/codes.json";
+          String filePath = GeckoCodeJSON.CODE_FILE_PATH;
           workspace.addFile(new WorkspaceFile(filePath, 0, 0, null, false));
           currentChangedFiles.add(filePath);
         }
@@ -2043,8 +2043,8 @@ public class MenuController {
    */
   private Path getCodesFile() throws IOException {
     // For passivity, handle a codes.json in the main workspace directory
-    Path oldCodePath = workspaceDirectory.resolve(GeckoCodeJSON.CODE_FILE);
-    Path codePath = uncompressedFiles.resolve(GeckoCodeJSON.PACKED_CODE_FILE_PATH);
+    Path oldCodePath = workspaceDirectory.resolve(GeckoCodeJSON.LEGACY_CODE_FILE);
+    Path codePath = uncompressedFiles.resolve(GeckoCodeJSON.CODE_FILE);
     if (Files.exists(oldCodePath)) {
       Files.createDirectories(codePath.getParent());
       Files.move(oldCodePath, codePath);

--- a/src/main/java/com/github/nicholasmoser/gnt4/dol/DolHijack.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/dol/DolHijack.java
@@ -105,10 +105,11 @@ public class DolHijack {
    *
    * @param dolPath  The path to the dol.
    * @param codeCave The code cave to write codes to.
+   * @param codePath The file to write the codes to.
    * @return If codes were found to be injected and a new codes JSON file was created.
    * @throws IOException if an I/O error occurs
    */
-  public static boolean handleActiveCodesButNoCodeFile(Path dolPath, CodeCave codeCave)
+  public static boolean handleActiveCodesButNoCodeFile(Path dolPath, CodeCave codeCave, Path codePath)
       throws IOException {
     byte[] currentBytes = getCurrentBytes(dolPath, codeCave);
     byte[] originalBytes = CodeCaves.getBytes(codeCave);
@@ -153,8 +154,7 @@ public class DolHijack {
             "A code could not be matched when creating the code JSON, please report this on the GNTool Github.");
       }
       // Write the codes list to the codes.json file
-      Path codesJson = dolPath.getParent().resolve("../../codes.json");
-      Files.writeString(codesJson, codesList.toString(2));
+      Files.writeString(codePath, codesList.toString(2));
       break;
     }
     return true;

--- a/src/main/java/com/github/nicholasmoser/workspace/SQLiteWorkspaceState.java
+++ b/src/main/java/com/github/nicholasmoser/workspace/SQLiteWorkspaceState.java
@@ -190,6 +190,19 @@ public class SQLiteWorkspaceState implements WorkspaceState {
   }
 
   @Override
+  public boolean fileExists(String filePath) throws IOException {
+    LOGGER.info("Getting file " + filePath + " from workspace state");
+    try (PreparedStatement stmt = conn.prepareStatement(SELECT_FILE)) {
+      stmt.setString(1, filePath);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next();
+      }
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
   public void delete() throws IOException {
     LOGGER.info("Deleting all files from workspace state");
     try (PreparedStatement stmt = conn.prepareStatement(DELETE_ALL_FILES)) {
@@ -274,20 +287,6 @@ public class SQLiteWorkspaceState implements WorkspaceState {
       throw new IOException(e);
     }
     return mapping;
-  }
-
-  @Override
-  public boolean isSavingCodeState() throws IOException {
-    String filePath = "files/extra/codes.json";
-    LOGGER.info("Getting file " + filePath + " from workspace state");
-    try (PreparedStatement stmt = conn.prepareStatement(SELECT_FILE)) {
-      stmt.setString(1, filePath);
-      try (ResultSet rs = stmt.executeQuery()) {
-        return rs.next();
-      }
-    } catch (SQLException e) {
-      throw new IOException(e);
-    }
   }
 
   @Override

--- a/src/main/java/com/github/nicholasmoser/workspace/SQLiteWorkspaceState.java
+++ b/src/main/java/com/github/nicholasmoser/workspace/SQLiteWorkspaceState.java
@@ -277,6 +277,20 @@ public class SQLiteWorkspaceState implements WorkspaceState {
   }
 
   @Override
+  public boolean isSavingCodeState() throws IOException {
+    String filePath = "files/extra/codes.json";
+    LOGGER.info("Getting file " + filePath + " from workspace state");
+    try (PreparedStatement stmt = conn.prepareStatement(SELECT_FILE)) {
+      stmt.setString(1, filePath);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next();
+      }
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
   public void close() {
     LOGGER.info("Closing workspace state");
     try {

--- a/src/main/java/com/github/nicholasmoser/workspace/WorkspaceState.java
+++ b/src/main/java/com/github/nicholasmoser/workspace/WorkspaceState.java
@@ -79,6 +79,12 @@ public interface WorkspaceState {
   Map<String, Long> getFilePathToModifiedDtTm() throws IOException;
 
   /**
+   * @return If the workspace is currently saving the state of dol codes.
+   * @throws IOException If any I/O exception occurs.
+   */
+  boolean isSavingCodeState() throws IOException;
+
+  /**
    * Closes the workspace state.
    */
   void close();

--- a/src/main/java/com/github/nicholasmoser/workspace/WorkspaceState.java
+++ b/src/main/java/com/github/nicholasmoser/workspace/WorkspaceState.java
@@ -41,6 +41,12 @@ public interface WorkspaceState {
   boolean removeFile(String filePath) throws IOException;
 
   /**
+   * @return If the given file exists.
+   * @throws IOException If any I/O exception occurs.
+   */
+  boolean fileExists(String filePath) throws IOException;
+
+  /**
    * Deletes the entire workspace state.
    */
   void delete() throws IOException;
@@ -77,12 +83,6 @@ public interface WorkspaceState {
    * @throws IOException If any I/O exception occurs.
    */
   Map<String, Long> getFilePathToModifiedDtTm() throws IOException;
-
-  /**
-   * @return If the workspace is currently saving the state of dol codes.
-   * @throws IOException If any I/O exception occurs.
-   */
-  boolean isSavingCodeState() throws IOException;
 
   /**
    * Closes the workspace state.


### PR DESCRIPTION
- If user is not bundling the codes.json file, query them to do so on each build. Otherwise the codes may fail to be parsed when creating new workspaces from the ISO.
- Refresh before each build so that all new file changes are accounted for.