### PR TITLE
Add ability to do quick refresh and full refresh

### DIFF
--- a/src/main/java/com/github/nicholasmoser/Workspace.java
+++ b/src/main/java/com/github/nicholasmoser/Workspace.java
@@ -78,10 +78,11 @@ public interface Workspace {
    * Returns the files that have been changed.
    *
    * @param allFiles All files currently in the workspace state.
+   * @param quick    If this call should be done in a less accurate but more quick way
    * @return The collection of changed files.
    * @throws IOException If any I/O exception occurs.
    */
-  Set<String> getChangedFiles(List<WorkspaceFile> allFiles) throws IOException;
+  Set<String> getChangedFiles(List<WorkspaceFile> allFiles, boolean quick) throws IOException;
 
   /**
    * Reverts changed files.

--- a/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
+++ b/src/main/resources/com/github/nicholasmoser/gnt4/menu.fxml
@@ -29,7 +29,8 @@
   <MenuBar VBox.vgrow="NEVER">
     <Menu mnemonicParsing="false" text="File">
       <MenuItem mnemonicParsing="false" onAction="#openDirectory" text="Open Workspace" />
-      <MenuItem accelerator="F5" mnemonicParsing="false" onAction="#refresh" text="Refresh" />
+      <MenuItem accelerator="F5" mnemonicParsing="false" onAction="#quickRefresh" text="Quick Refresh" />
+      <MenuItem mnemonicParsing="false" onAction="#fullRefresh" text="Full Refresh" />
          <MenuItem mnemonicParsing="false" onAction="#diffWorkspace" text="Diff Workspace" />
          <SeparatorMenuItem mnemonicParsing="false" text="Files" />
       <MenuItem accelerator="F7" mnemonicParsing="false" onAction="#addFile" text="Add File" />


### PR DESCRIPTION
Fixes #150

Originally GNTool would hash every file in the workspace when refreshing. This is very slow, especially on mechanical hard drives. This was replaced with new code that only hash files with a last modified date/time after the last build. This drastically sped up refreshes, but created a problem when you copied a file with a modified date/time in the past. You could not detect this file without manually modifying it to update the modified date/time.

Now, there is both a quick and full refresh option. Full refresh only occurs when requested. When doing a full refresh, any files with modified date/times before the last build will be updated to the current date/time. This is done so that any new quick refreshes will now see this file.