### PR TITLE
Add support for disassembling more SEQ files

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqHelper.java
@@ -30,6 +30,7 @@ import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup1F;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup20;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup21;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup22;
+import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup23;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup24;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup26;
 import com.github.nicholasmoser.gnt4.seq.groups.OpcodeGroup27;
@@ -143,6 +144,7 @@ public class SeqHelper {
       case 0x20 -> OpcodeGroup20.parse(bs, opcode);
       case 0x21 -> OpcodeGroup21.parse(bs, opcode);
       case 0x22 -> OpcodeGroup22.parse(bs, opcode);
+      case 0x23 -> OpcodeGroup23.parse(bs, opcode);
       case 0x24 -> OpcodeGroup24.parse(bs, opcode);
       case 0x26 -> OpcodeGroup26.parse(bs, opcode);
       case 0x27 -> OpcodeGroup27.parse(bs, opcode);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
@@ -221,6 +221,14 @@ public class SeqKing {
         //binaryOffsetToSize.put(0xF420, 0x43C);
         //binaryOffsetToSize.put(0xFAE0, 0x14B4);
       }
+      case Seqs.CHARSEL_4 -> {
+        binaryOffsetToSize.put(0x950, 0x14);
+        binaryOffsetToSize.put(0x9A0, 0xc);
+        binaryOffsetToSize.put(0x2370, 0x80);
+        binaryOffsetToSize.put(0x23F0, 0x80);
+        binaryOffsetToSize.put(0x13FF0, 0x4EC);
+        binaryOffsetToSize.put(0x149E0, 0xE88);
+      }
       case Seqs.NAR_0000 -> {
         binaryOffsetToSize.put(0x30C4C, 0x14);
         binaryOffsetToSize.put(0x319B0, 0x10);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
@@ -276,6 +276,13 @@ public class SeqKing {
         binaryOffsetToSize.put(0x1C130, 0x162E0);
         binaryOffsetToSize.put(0x32410, 0x8C0); // array of offsets?
       }
+      case Seqs.STG_001_0000 -> {
+        binaryOffsetToSize.put(0x4C0, 0x220);
+        binaryOffsetToSize.put(0x8CBC, 0xB0);
+        binaryOffsetToSize.put(0x9260, 0x10);
+        binaryOffsetToSize.put(0x92B0, 0x10);
+        binaryOffsetToSize.put(0x9300, 0x10);
+      }
     }
     return binaryOffsetToSize;
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/SeqKing.java
@@ -283,6 +283,11 @@ public class SeqKing {
         binaryOffsetToSize.put(0x92B0, 0x10);
         binaryOffsetToSize.put(0x9300, 0x10);
       }
+      case Seqs.STG_001_0100 -> binaryOffsetToSize.put(0x20, 0x10);
+      case Seqs.M_GAL -> binaryOffsetToSize.put(0x28C0, 0x10);
+      case Seqs.M_NFILE -> binaryOffsetToSize.put(0x3AD0, 0xA44);
+      case Seqs.M_SNDPLR -> binaryOffsetToSize.put(0x50B0, 0x1CC0);
+      case Seqs.M_VIEWER -> binaryOffsetToSize.put(0x7610, 0x64A0);
     }
     return binaryOffsetToSize;
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Comments.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/comment/Comments.java
@@ -306,6 +306,10 @@ public class Comments {
     game00Comments.put(0x4CB4, "// Fully show health bars at end of animation");
     allComments.put(Seqs.GAME_00, game00Comments);
 
+    Multimap<Integer, String> titleComments = ArrayListMultimap.create();
+    game00Comments.put(0x717C, "// Branch based on month background theme");
+    allComments.put(Seqs.M_TITLE, titleComments);
+
     // m_vs.seq 0x3838 Reads the character costume ID
     // m_vs.seq 0x3840 Does something with the character costume ID
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup10.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup10.java
@@ -15,7 +15,9 @@ public class OpcodeGroup10 {
       case 0x00 -> op_1000(bs);
       case 0x04 -> op_1004(bs);
       case 0x05 -> op_1005(bs);
+      case 0x06 -> op_1006(bs);
       case 0x07 -> op_1007(bs);
+      case 0x08 -> op_1008(bs);
       case 0x09 -> op_1009(bs);
       case 0x0D -> op_100D(bs);
       case 0x1A -> op_101A(bs);
@@ -43,7 +45,19 @@ public class OpcodeGroup10 {
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
+  private static Opcode op_1006(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
   private static Opcode op_1007(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1008(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup12.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup12.java
@@ -21,11 +21,15 @@ public class OpcodeGroup12 {
       case 0x09 -> op_1209(bs);
       case 0x0A -> op_120A(bs);
       case 0x0B -> op_120B(bs);
+      case 0x15 -> op_1215(bs);
+      case 0x17 -> op_1217(bs);
+      case 0x18 -> op_1218(bs);
       case 0x19 -> op_1219(bs);
       case 0x1A -> op_121A(bs);
       case 0x1B -> op_121B(bs);
       case 0x1D -> op_121D(bs);
       case 0x1E -> op_121E(bs);
+      case 0x1F -> UnknownOpcode.of(0x10, bs);
       case 0x20 -> UnknownOpcode.of(0x4, bs);
       case 0x22 -> op_1222(bs);
       case 0x24 -> op_1224(bs);
@@ -79,6 +83,24 @@ public class OpcodeGroup12 {
   }
 
   private static Opcode op_120B(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1215(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1217(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1218(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup14.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup14.java
@@ -14,6 +14,8 @@ public class OpcodeGroup14 {
     return switch (opcodeByte) {
       case 0x00 -> op_1400(bs);
       case 0x04 -> op_1404(bs);
+      case 0x06 -> op_1406(bs);
+      case 0x08 -> op_1408(bs);
       case 0x09 -> op_1409(bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
@@ -30,6 +32,19 @@ public class OpcodeGroup14 {
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     byte[] bytes = bs.readBytes(0x14);
     return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+  }
+
+  private static Opcode op_1406(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    byte[] bytes = bs.readBytes(0x20);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+  }
+
+  private static Opcode op_1408(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_1409(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
@@ -17,6 +17,7 @@ public class OpcodeGroup16 {
       case 0x06 -> UnknownOpcode.of(0x4, bs);
       case 0x07 -> op_1607(bs);
       case 0x08 -> op_1608(bs);
+      case 0x09 -> op_1609(bs);
       case 0x0C -> op_160C(bs);
       case 0x0D -> UnknownOpcode.of(0x4, bs);
       case 0x0E -> UnknownOpcode.of(0x4, bs);
@@ -47,6 +48,12 @@ public class OpcodeGroup16 {
   }
 
   private static Opcode op_1608(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1609(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup16.java
@@ -17,6 +17,8 @@ public class OpcodeGroup16 {
       case 0x06 -> UnknownOpcode.of(0x4, bs);
       case 0x07 -> op_1607(bs);
       case 0x08 -> op_1608(bs);
+      case 0x0C -> op_160C(bs);
+      case 0x0D -> UnknownOpcode.of(0x4, bs);
       case 0x0E -> UnknownOpcode.of(0x4, bs);
       case 0x0F -> op_160F(bs);
       case 0x10 -> op_1610(bs);
@@ -45,6 +47,12 @@ public class OpcodeGroup16 {
   }
 
   private static Opcode op_1608(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_160C(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1A.java
@@ -17,12 +17,14 @@ public class OpcodeGroup1A {
       case 0x19 -> op_1A19(bs);
       case 0x1B -> op_1A1B(bs);
       case 0x1D -> op_1A1D(bs);
+      case 0x1E -> op_1A1E(bs);
       case 0x1F -> op_1A1F(bs);
       case 0x20 -> op_1A20(bs);
       case 0x21 -> op_1A21(bs);
       case 0x28 -> op_1A28(bs);
       case 0x29 -> op_1A29(bs);
       case 0x2A -> op_1A2A(bs);
+      case 0x2B -> op_1A2B(bs);
       case 0x31 -> op_1A31(bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
@@ -59,6 +61,12 @@ public class OpcodeGroup1A {
     return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 
+  private static Opcode op_1A1E(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
   private static Opcode op_1A1F(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
@@ -93,6 +101,12 @@ public class OpcodeGroup1A {
   private static Opcode op_1A2A(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1A2B(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1E.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup1E.java
@@ -11,7 +11,9 @@ public class OpcodeGroup1E {
   public static Opcode parse(ByteStream bs, byte opcodeByte) throws IOException {
     return switch (opcodeByte) {
       case 0x02 -> op_1E02(bs);
+      case 0x03 -> op_1E03(bs);
       case 0x05 -> UnknownOpcode.of(0x4, bs);
+      case 0x04 -> op_1E04(bs);
       case 0x06 -> op_1E06(bs);
       case 0x07 -> op_1E07(bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
@@ -19,6 +21,18 @@ public class OpcodeGroup1E {
   }
 
   private static Opcode op_1E02(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1E03(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_1E04(ByteStream bs) throws IOException {
     int offset = bs.offset();
     SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
     return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup21.java
@@ -37,6 +37,8 @@ public class OpcodeGroup21 {
       case 0x15 -> op_2115(bs);
       case 0x16 -> op_2116(bs);
       case 0x17 -> op_2117(bs);
+      case 0x18 -> op_2118(bs);
+      case 0x19 -> op_2119(bs);
       case 0x1A -> op_211A(bs);
       case 0x1D -> op_211D(bs);
       case 0x1E -> op_211E(bs);
@@ -179,6 +181,18 @@ public class OpcodeGroup21 {
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     byte[] bytes = bs.readBytes(8);
     return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+  }
+
+  private static Opcode op_2118(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_2119(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 
   private static Opcode op_211A(ByteStream bs) throws IOException {

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup23.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup23.java
@@ -1,0 +1,67 @@
+package com.github.nicholasmoser.gnt4.seq.groups;
+
+import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD1;
+import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD2;
+import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
+import com.github.nicholasmoser.gnt4.seq.opcodes.UnknownOpcode;
+import com.github.nicholasmoser.utils.ByteStream;
+import com.google.common.primitives.Bytes;
+import java.io.IOException;
+
+public class OpcodeGroup23 {
+  public static Opcode parse(ByteStream bs, byte opcodeByte) throws IOException {
+    return switch (opcodeByte) {
+      case 0x00 -> op_2300(bs);
+      case 0x01 -> op_2301(bs);
+      case 0x02 -> op_2302(bs);
+      case 0x05 -> op_2305(bs);
+      case 0x06 -> op_2306(bs);
+      case 0x0D -> op_230D(bs);
+      case 0x10 -> op_2310(bs);
+      default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
+    };
+  }
+
+  private static Opcode op_2300(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_2301(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_2302(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_2305(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_2306(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+
+  private static Opcode op_230D(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    byte[] bytes = bs.readNBytes(4);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+  }
+
+  private static Opcode op_2310(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD2 ea = SEQ_RegCMD2.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
+  }
+}

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup38.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup38.java
@@ -11,6 +11,7 @@ public class OpcodeGroup38 {
       case 0x00 -> UnknownOpcode.of(0x14, bs);
       case 0x01 -> UnknownOpcode.of(0x14, bs);
       case 0x02 -> UnknownOpcode.of(0x14, bs);
+      case 0x05 -> UnknownOpcode.of(0x1C, bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup39.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup39.java
@@ -19,6 +19,7 @@ public class OpcodeGroup39 {
       case 0x09 -> UnknownOpcode.of(0x24, bs);
       case 0x0B -> UnknownOpcode.of(0x10, bs);
       case 0x0C -> UnknownOpcode.of(0x14, bs);
+      case 0x0E -> UnknownOpcode.of(0x10, bs);
       case 0x0F -> UnknownOpcode.of(0x10, bs);
       case 0x11 -> UnknownOpcode.of(0x10, bs);
       case 0x12 -> UnknownOpcode.of(0xc, bs);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3A.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3A.java
@@ -12,6 +12,7 @@ public class OpcodeGroup3A {
       case 0x01 -> UnknownOpcode.of(0x0c, bs);
       case 0x02 -> UnknownOpcode.of(0x18, bs);
       case 0x05 -> UnknownOpcode.of(0x1c, bs);
+      case 0x08 -> UnknownOpcode.of(0x10, bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3B.java
@@ -17,6 +17,7 @@ public class OpcodeGroup3B {
       case 0x06 -> UnknownOpcode.of(0x10, bs);
       case 0x07 -> UnknownOpcode.of(0x10, bs);
       case 0x08 -> UnknownOpcode.of(0x10, bs);
+      case 0x09 -> UnknownOpcode.of(0x10, bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3C.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup3C.java
@@ -29,6 +29,7 @@ public class OpcodeGroup3C {
       case 0x16 -> UnknownOpcode.of(0x10, bs);
       case 0x17 -> UnknownOpcode.of(0x10, bs);
       case 0x18 -> UnknownOpcode.of(0x14, bs);
+      case 0x19 -> UnknownOpcode.of(0x10, bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup40.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup40.java
@@ -21,6 +21,7 @@ public class OpcodeGroup40 {
       case 0x06 -> UnknownOpcode.of(0x8, bs);
       case 0x07 -> UnknownOpcode.of(0x8, bs);
       case 0x0E -> UnknownOpcode.of(0x4, bs);
+      case 0x0F -> UnknownOpcode.of(0x4, bs);
       case 0x12 -> UnknownOpcode.of(0x10, bs);
       case 0x1E -> op_401E(bs);
       case 0x1F -> op_401F(bs);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup41.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup41.java
@@ -1,5 +1,6 @@
 package com.github.nicholasmoser.gnt4.seq.groups;
 
+import com.github.nicholasmoser.gnt4.seq.SEQ_RegCMD1;
 import com.github.nicholasmoser.gnt4.seq.opcodes.Opcode;
 import com.github.nicholasmoser.gnt4.seq.opcodes.UnknownOpcode;
 import com.github.nicholasmoser.utils.ByteStream;
@@ -9,9 +10,11 @@ public class OpcodeGroup41 {
 
   public static Opcode parse(ByteStream bs, byte opcodeByte) throws IOException {
     return switch (opcodeByte) {
+      case 0x00 -> UnknownOpcode.of(0x4, bs);
       case 0x03 -> UnknownOpcode.of(0xc, bs);
       case 0x04 -> UnknownOpcode.of(0xc, bs);
       case 0x06 -> UnknownOpcode.of(0x1c, bs);
+      case 0x07 -> op_4107(bs);
       case 0x08 -> UnknownOpcode.of(0x4, bs);
       case 0x09 -> UnknownOpcode.of(0x4, bs);
       case 0x0A -> UnknownOpcode.of(0x8, bs);
@@ -21,5 +24,11 @@ public class OpcodeGroup41 {
       case 0x0E -> UnknownOpcode.of(0x8, bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
+  }
+
+  private static Opcode op_4107(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
+    return new UnknownOpcode(offset, ea.getBytes(), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4B.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup4B.java
@@ -17,6 +17,8 @@ public class OpcodeGroup4B {
       case 0x05 -> op_4B05(bs);
       case 0x06 -> UnknownOpcode.of(0x4, bs);
       case 0x07 -> op_4B07(bs);
+      case 0x0D -> UnknownOpcode.of(0x10, bs);
+      case 0x0F -> op_4B0F(bs);
       default -> throw new IOException(String.format("Unimplemented: %02X", opcodeByte));
     };
   }
@@ -37,6 +39,13 @@ public class OpcodeGroup4B {
     int offset = bs.offset();
     SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
     byte[] bytes = bs.readBytes(0x8);
+    return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
+  }
+
+  private static Opcode op_4B0F(ByteStream bs) throws IOException {
+    int offset = bs.offset();
+    SEQ_RegCMD1 ea = SEQ_RegCMD1.get(bs);
+    byte[] bytes = bs.readNBytes(0x4);
     return new UnknownOpcode(offset, Bytes.concat(ea.getBytes(), bytes), ea.getDescription());
   }
 }

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
@@ -22,6 +22,7 @@ public class OpcodeGroup61 {
       case 0x14 -> UnknownOpcode.of(0x8, bs);
       case 0x15 -> UnknownOpcode.of(0xC, bs);
       case 0x17 -> UnknownOpcode.of(0xC, bs);
+      case 0x18 -> UnknownOpcode.of(0x14, bs);
       case 0x2C -> UnknownOpcode.of(0x8, bs);
       case 0x32 -> UnknownOpcode.of(0x8, bs);
       case 0x33 -> UnknownOpcode.of(0x8, bs);
@@ -31,6 +32,7 @@ public class OpcodeGroup61 {
       case 0x48 -> UnknownOpcode.of(0x8, bs);
       case 0x49 -> UnknownOpcode.of(0x8, bs);
       case 0x4C -> UnknownOpcode.of(0x8, bs);
+      case 0x4E -> UnknownOpcode.of(0x8, bs);
       case 0x50 -> UnknownOpcode.of(0x4, bs);
       case 0x52 -> UnknownOpcode.of(0x14, bs);
       case 0x53 -> UnknownOpcode.of(0x10, bs);
@@ -47,6 +49,7 @@ public class OpcodeGroup61 {
       case 0x6E -> UnknownOpcode.of(0x14, bs);
       case (byte) 0x8C -> UnknownOpcode.of(0x8, bs);
       case (byte) 0x8D -> UnknownOpcode.of(0x4, bs);
+      case (byte) 0x8F -> UnknownOpcode.of(0x8, bs);
       case (byte) 0x99 -> UnknownOpcode.of(0x8, bs);
       case (byte) 0x9F -> UnknownOpcode.of(0x8, bs);
       case (byte) 0xAA -> UnknownOpcode.of(0x14, bs);

--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/groups/OpcodeGroup61.java
@@ -47,6 +47,9 @@ public class OpcodeGroup61 {
       case 0x6B -> UnknownOpcode.of(0x1C, bs);
       case 0x6C -> UnknownOpcode.of(0x10, bs);
       case 0x6E -> UnknownOpcode.of(0x14, bs);
+      case 0x70 -> UnknownOpcode.of(0xC, bs);
+      case (byte) 0x85 -> UnknownOpcode.of(0x8, bs);
+      case (byte) 0x86 -> UnknownOpcode.of(0x4, bs);
       case (byte) 0x8C -> UnknownOpcode.of(0x8, bs);
       case (byte) 0x8D -> UnknownOpcode.of(0x4, bs);
       case (byte) 0x8F -> UnknownOpcode.of(0x8, bs);
@@ -57,6 +60,8 @@ public class OpcodeGroup61 {
       case (byte) 0xAC -> UnknownOpcode.of(0x14, bs);
       case (byte) 0xAD -> UnknownOpcode.of(0x14, bs);
       case (byte) 0xAE -> UnknownOpcode.of(0xC, bs);
+      case (byte) 0xC8 -> UnknownOpcode.of(0x8, bs);
+      case (byte) 0xC9 -> UnknownOpcode.of(0x4, bs);
       case (byte) 0xF0 -> UnknownOpcode.of(0xC, bs);
       case (byte) 0xF3 -> UnknownOpcode.of(0x4, bs);
       case (byte) 0xF4 -> UnknownOpcode.of(0x4, bs);

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -22,7 +22,7 @@ public class SeqKingTest {
 
   @Test
   public void parseTitle() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/maki/m_title.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_TITLE);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -32,7 +32,7 @@ public class SeqKingTest {
 
   @Test
   public void parseGame00() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/game/game00.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.GAME_00);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -42,7 +42,7 @@ public class SeqKingTest {
 
   @Test
   public void parseChrCmn() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/cmn/1000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CMN_1000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -52,7 +52,7 @@ public class SeqKingTest {
 
   @Test
   public void parseLoading() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/kuro/loading.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.LOADING);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -62,7 +62,7 @@ public class SeqKingTest {
 
   @Test
   public void parseFCamera() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/furu/f_camera.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.F_CAMERA);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -72,7 +72,7 @@ public class SeqKingTest {
 
   @Test
   public void parseCamera00() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/game/camera00.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CAMERA_00);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -82,7 +82,7 @@ public class SeqKingTest {
 
   @Test
   public void parseCamera01() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/game/camera01.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CAMERA_01);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -92,7 +92,7 @@ public class SeqKingTest {
 
   @Test
   public void parsePlayer00() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/game/player00.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.PLAYER_00);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -102,7 +102,7 @@ public class SeqKingTest {
 
   @Test
   public void parseCharSel() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/maki/char_sel.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CHARSEL);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -112,7 +112,7 @@ public class SeqKingTest {
 
   @Test
   public void parseAnko() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/ank/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.ANK_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -122,7 +122,7 @@ public class SeqKingTest {
 
   @Test
   public void parseJirobo() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/bou/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.BOU_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -132,7 +132,7 @@ public class SeqKingTest {
 
   @Test
   public void parseChoji() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/cho/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CHO_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -142,7 +142,7 @@ public class SeqKingTest {
 
   @Test
   public void parseAkamaru() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/dog/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.DOG_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -152,7 +152,7 @@ public class SeqKingTest {
 
   @Test
   public void parseGai() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/gai/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.GAI_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -162,7 +162,7 @@ public class SeqKingTest {
 
   @Test
   public void parseGaara() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/gar/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.GAR_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -172,7 +172,7 @@ public class SeqKingTest {
 
   @Test
   public void parseHaku() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/hak/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.HAK_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -182,7 +182,7 @@ public class SeqKingTest {
 
   @Test
   public void parseWokeHinata() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/hi2/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.HI2_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -192,7 +192,7 @@ public class SeqKingTest {
 
   @Test
   public void parseHinata() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/hin/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.HIN_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -202,7 +202,7 @@ public class SeqKingTest {
 
   @Test
   public void parseIno() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/ino/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.INO_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -212,7 +212,7 @@ public class SeqKingTest {
 
   @Test
   public void parseIruka() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/iru/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.IRU_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -222,7 +222,7 @@ public class SeqKingTest {
 
   @Test
   public void parseItachi() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/ita/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.ITA_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -232,7 +232,7 @@ public class SeqKingTest {
 
   @Test
   public void parseJiraiya() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/jir/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.JIR_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -242,7 +242,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKabuto() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kab/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KAB_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -252,7 +252,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKakashi() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kak/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KAK_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -262,7 +262,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKankuro() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kan/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KAN_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -272,7 +272,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKarasu() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kar/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KAR_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -282,7 +282,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKiba() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kib/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KIB_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -292,7 +292,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKidomaru() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kid/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KID_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -302,7 +302,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKimimaro() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kim/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KIM_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -312,7 +312,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKisame() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/kis/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.KIS_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -322,7 +322,7 @@ public class SeqKingTest {
 
   @Test
   public void parseLee() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/loc/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.LOC_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -332,7 +332,7 @@ public class SeqKingTest {
 
   @Test
   public void parseMizuki() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/miz/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.MIZ_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -342,7 +342,7 @@ public class SeqKingTest {
 
   @Test
   public void parseKyuubiNaruto() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/na9/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.NA9_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -352,7 +352,7 @@ public class SeqKingTest {
 
   @Test
   public void parseNaruto() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/nar/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.NAR_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -362,7 +362,7 @@ public class SeqKingTest {
 
   @Test
   public void parseNeji() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/nej/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.NEJ_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -372,7 +372,7 @@ public class SeqKingTest {
 
   @Test
   public void parseOboro() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/obo/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.OBO_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -382,7 +382,7 @@ public class SeqKingTest {
 
   @Test
   public void parseOrochimaru() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/oro/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.ORO_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -392,7 +392,7 @@ public class SeqKingTest {
 
   @Test
   public void parseCS2Sasuke() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sa2/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SA2_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -402,7 +402,7 @@ public class SeqKingTest {
 
   @Test
   public void parseSakura() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sak/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SAK_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -412,7 +412,7 @@ public class SeqKingTest {
 
   @Test
   public void parseSarutobi() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sar/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SAR_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -422,7 +422,7 @@ public class SeqKingTest {
 
   @Test
   public void parseSasuke() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sas/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SAS_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -432,7 +432,7 @@ public class SeqKingTest {
 
   @Test
   public void parseShikamaru() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sik/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SIK_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -442,7 +442,7 @@ public class SeqKingTest {
 
   @Test
   public void parseShino() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sin/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SIN_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -452,7 +452,7 @@ public class SeqKingTest {
 
   @Test
   public void parseSakon() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/sko/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.SKO_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -462,7 +462,7 @@ public class SeqKingTest {
 
   @Test
   public void parseDokiDemon() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/ta2/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.TA2_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -472,7 +472,7 @@ public class SeqKingTest {
 
   @Test
   public void parseTayuya() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/tay/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.TAY_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -482,7 +482,7 @@ public class SeqKingTest {
 
   @Test
   public void parseTemari() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/tem/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.TEM_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -492,7 +492,7 @@ public class SeqKingTest {
 
   @Test
   public void parseTenten() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/ten/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.TEN_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -502,7 +502,7 @@ public class SeqKingTest {
 
   @Test
   public void parseTsunade() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/tsu/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.TSU_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -512,7 +512,7 @@ public class SeqKingTest {
 
   @Test
   public void parseZabuza() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/zab/0000.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.ZAB_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {
@@ -522,7 +522,27 @@ public class SeqKingTest {
 
   @Test
   public void parseIruka0010() throws Exception {
-    Path seq = Prereqs.getUncompressedGNT4().resolve("files/chr/iru/0010.seq");
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.IRU_0010);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseCharSel4() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.CHARSEL_4);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseStg001_0000() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.STG_001_0000);
     if (COMPARE_MODE) {
       compare(seq);
     } else {

--- a/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
+++ b/src/test/java/com/github/nicholasmoser/gnt4/seq/SeqKingTest.java
@@ -550,6 +550,66 @@ public class SeqKingTest {
     }
   }
 
+  @Test
+  public void parseStg001_0100() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.STG_001_0100);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseMGal() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_GAL);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseMNFile() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_NFILE);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseMNSiki() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_NSIKI);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseMSndplr() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_SNDPLR);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
+  @Test
+  public void parseMViewer() throws Exception {
+    Path seq = Prereqs.getUncompressedGNT4().resolve(Seqs.M_VIEWER);
+    if (COMPARE_MODE) {
+      compare(seq);
+    } else {
+      generate(seq);
+    }
+  }
+
   private void compare(Path seq) throws Exception {
     Path outputPath = null;
     try {


### PR DESCRIPTION
These changes add support for disassembling the following SEQ files:

- files/maki/charsel4.seq
- files/maki/m_gal.seq
- files/maki/m_nfile.seq
- files/maki/m_nsiki.seq
- files/maki/m_sndplr.seq
- files/maki/m_viewer.seq
- files/stg/001/0000.seq
- files/stg/001/0100.seq

You can find the latest vanilla GNT4 disassembled files here: https://gnt4.online/seq/seqs.html

This PR also adds more code to handle Extra Data sections for SCON4 that are malformed.

Note: This is the first time we've disassembled stage SEQ files, so hopefully we soon should be able to edit stage code!