### PR TITLE
Allow receiving multiple SEQ events in a single UDP Packet

### DIFF
--- a/src/main/java/com/github/nicholasmoser/gnt4/seq/DolphinSeqListener.java
+++ b/src/main/java/com/github/nicholasmoser/gnt4/seq/DolphinSeqListener.java
@@ -70,6 +70,7 @@ public class DolphinSeqListener {
   private Stage stage;
   private Path gnt4Files;
   private String lastSearch = "";
+  private boolean isListenerRunning = false;
 
   public void quit() {
     killListener();
@@ -246,7 +247,8 @@ public class DolphinSeqListener {
       initMessageProducer();
       initMessageConsumer(bufferSizeValue);
       leftStatus.setText("Connected");
-    } else {
+      isListenerRunning = true;
+    } else if (!isListenerRunning) {
       leftStatus.setText("Failed to Connect to Dolphin");
       Message.error("Failed to Connect to Dolphin", "Please restart GNTool.");
     }
@@ -256,6 +258,7 @@ public class DolphinSeqListener {
     try {
       if (producer != null && !producer.isInterrupted()) {
         producer.interrupt();
+        isListenerRunning = false;
       }
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, "Failed to stop Dolphin message producer", e);

--- a/src/main/java/com/github/nicholasmoser/utils/ByteStream.java
+++ b/src/main/java/com/github/nicholasmoser/utils/ByteStream.java
@@ -1,9 +1,11 @@
 package com.github.nicholasmoser.utils;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A ByteArrayInputStream enhanced with a few extra features. These include:
@@ -128,6 +130,22 @@ public class ByteStream extends ByteArrayInputStream {
       throw new IOException("Failed to read word at offset " + pos);
     }
     return ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getFloat();
+  }
+
+  /**
+   * Read the next null-terminated String and return it.
+   *
+   * @return The next null-terminated String.
+   * @throws IOException If an I/O error occurs.
+   */
+  public String readCString() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    int curr = read();
+    while (curr != 0 && curr != -1) {
+      baos.write(curr);
+      curr = read();
+    }
+    return baos.toString(StandardCharsets.UTF_8);
   }
 
   /**

--- a/src/test/java/com/github/nicholasmoser/utils/ByteUtilsTest.java
+++ b/src/test/java/com/github/nicholasmoser/utils/ByteUtilsTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.primitives.Bytes;
 import java.io.ByteArrayOutputStream;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
@@ -970,5 +971,27 @@ public class ByteUtilsTest {
     assertThat(ByteUtils.align(31, 8)).isEqualTo(32);
     assertThat(ByteUtils.align(32, 8)).isEqualTo(32);
     assertThat(ByteUtils.align(33, 8)).isEqualTo(40);
+  }
+
+  @Test
+  public void testReadCString() throws Exception {
+    byte[] oneString = "hello\0".getBytes(StandardCharsets.UTF_8);
+    byte[] threeStrings = "hello\0hi\0okay?\0".getBytes(StandardCharsets.UTF_8);
+
+    ByteStream bs = new ByteStream(oneString);
+    assertThat(bs.offset()).isEqualTo(0);
+    assertThat(bs.readCString()).isEqualTo("hello");
+    assertThat(bs.offset()).isEqualTo(6);
+    assertThat(bs.readCString()).isEqualTo("");
+    assertThat(bs.offset()).isEqualTo(6);
+
+    bs = new ByteStream(threeStrings);
+    assertThat(bs.offset()).isEqualTo(0);
+    assertThat(bs.readCString()).isEqualTo("hello");
+    assertThat(bs.offset()).isEqualTo(6);
+    assertThat(bs.readCString()).isEqualTo("hi");
+    assertThat(bs.offset()).isEqualTo(9);
+    assertThat(bs.readCString()).isEqualTo("okay?");
+    assertThat(bs.offset()).isEqualTo(15);
   }
 }


### PR DESCRIPTION
This PR adds the ability to handle multiple SEQ events sent from a single packet. This is useful to improve the performance of https://github.com/SCON-Development/dolphin-gnt4-debug/pull/1 since it is bottlenecked by the UDP implementation.

This PR also includes a small fix to hitting Start multiple times, it will no longer error and will instead see that it has already been Started and ignore subsequent clicks.